### PR TITLE
[Feat]: 한국투자증권 인메모리 방식과 스케줄링을 사용하여 AccessToken 발급

### DIFF
--- a/src/main/java/naughty/tuzamate/TuzamateApplication.java
+++ b/src/main/java/naughty/tuzamate/TuzamateApplication.java
@@ -3,9 +3,11 @@ package naughty.tuzamate;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class TuzamateApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/naughty/tuzamate/auth/hantu/ApiTokenInMemoryStore.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/ApiTokenInMemoryStore.java
@@ -1,0 +1,38 @@
+package naughty.tuzamate.auth.hantu;
+
+import naughty.tuzamate.auth.hantu.repository.ApiTokenStore;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+@Component
+@Primary
+public class ApiTokenInMemoryStore implements ApiTokenStore {
+
+    private String accessToken;
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    @Override
+    public void saveAccessToken(String accessToken) {
+
+        lock.writeLock().lock();
+        try {
+            this.accessToken = accessToken;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public String getAccessToken() {
+
+        lock.readLock().lock();
+        try {
+            return this.accessToken;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+}

--- a/src/main/java/naughty/tuzamate/auth/hantu/ApiTokenRefreshScheduler.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/ApiTokenRefreshScheduler.java
@@ -1,0 +1,46 @@
+package naughty.tuzamate.auth.hantu;
+
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import naughty.tuzamate.auth.hantu.service.ApiTokenService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 토큰 자동 갱신 스케줄러
+ * 24시간마다 한 번씩
+ * 잦은 AccessToken 발급은 API 사용이 제한될 수 있다고 한다.
+ * 따라서 실제 서비스 전까지는 주석처리를 해놓는다.
+ */
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class ApiTokenRefreshScheduler {
+
+    /* private final ApiTokenService apiTokenService;
+
+    @PostConstruct
+    public void firstToken() {
+
+        log.info("처음 HanTu API AccessToken 발급");
+        boolean result = apiTokenService.refreshAccessToken();
+        if (!result) {
+            log.error("API AccessToken 발급 실패");
+        }
+    }
+
+    // 초, 분, 시, 일, 월, 요일
+    @Scheduled(cron = "0 10 17 * * *")
+    public void refreshDailyToken() {
+
+        boolean result = apiTokenService.refreshAccessToken();
+        if (result) {
+            log.info("API AccessToken 갱신 완료");
+        } else {
+            log.error("API AccessToken 갱신 실패");
+        }
+    }*/
+}

--- a/src/main/java/naughty/tuzamate/auth/hantu/ApiTokenRefreshScheduler.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/ApiTokenRefreshScheduler.java
@@ -5,6 +5,7 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import naughty.tuzamate.auth.hantu.service.ApiTokenService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -18,9 +19,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Component
 @Slf4j
+@ConditionalOnProperty(name = "hantu.token.schedule.enabled", havingValue = "true")
+// @ConditionalOnProperty를 사용하여 개발 중에는 이 클래스가 실행되지 않도록 한다.
 public class ApiTokenRefreshScheduler {
 
-    /* private final ApiTokenService apiTokenService;
+     private final ApiTokenService apiTokenService;
 
     @PostConstruct
     public void firstToken() {
@@ -42,5 +45,5 @@ public class ApiTokenRefreshScheduler {
         } else {
             log.error("API AccessToken 갱신 실패");
         }
-    }*/
+    }
 }

--- a/src/main/java/naughty/tuzamate/auth/hantu/dto/ResponseTuzaAccessTokenDto.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/dto/ResponseTuzaAccessTokenDto.java
@@ -1,0 +1,15 @@
+package naughty.tuzamate.auth.hantu.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResponseTuzaAccessTokenDto {
+
+    private String accessToken;
+    private String tokenType;
+    private Long expiresIn;
+    private String accessTokenTokenExpired;
+
+}

--- a/src/main/java/naughty/tuzamate/auth/hantu/repository/ApiTokenStore.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/repository/ApiTokenStore.java
@@ -1,0 +1,8 @@
+package naughty.tuzamate.auth.hantu.repository;
+
+public interface ApiTokenStore {
+
+    void saveAccessToken(String accessToken);
+
+    String getAccessToken();
+}

--- a/src/main/java/naughty/tuzamate/auth/hantu/service/ApiTokenService.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/service/ApiTokenService.java
@@ -52,7 +52,7 @@ public class ApiTokenService {
 
             ResponseEntity<ResponseTuzaAccessTokenDto> response = restTemplate.postForEntity(tokenUrl, request, ResponseTuzaAccessTokenDto.class);
 
-            if (response.getStatusCode() == HttpStatus.OK) {
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
                 apiTokenStore.saveAccessToken(response.getBody().getAccessToken());
                 log.info("HanTU Access Token 갱신 완료");
                 return true;

--- a/src/main/java/naughty/tuzamate/auth/hantu/service/ApiTokenService.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/service/ApiTokenService.java
@@ -1,0 +1,72 @@
+package naughty.tuzamate.auth.hantu.service;
+
+import lombok.extern.slf4j.Slf4j;
+import naughty.tuzamate.auth.hantu.dto.ResponseTuzaAccessTokenDto;
+import naughty.tuzamate.auth.hantu.repository.ApiTokenStore;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class ApiTokenService {
+
+    private final ApiTokenStore apiTokenStore;
+    private final RestTemplate restTemplate;
+
+    //    @Value("${tuza.api.APP_KEY}")
+    private final String appKey;
+
+    //    @Value("${tuza.api.APP_SECRET_KEY}")
+    private final String appSecret;
+
+    //    @Value("${tuza.api.URL}")
+    private final String tokenUrl;
+
+    public ApiTokenService(ApiTokenStore apiTokenStore, RestTemplate restTemplate, @Value("${tuza.api.APP_KEY}") String appKey, @Value("${tuza.api.APP_SECRET_KEY}") String appSecret, @Value("${tuza.api.URL}") String tokenUrl) {
+        this.apiTokenStore = apiTokenStore;
+        this.restTemplate = restTemplate;
+        this.appKey = appKey;
+        this.appSecret = appSecret;
+        this.tokenUrl = tokenUrl;
+    }
+
+    public boolean refreshAccessToken() {
+
+        try {
+            log.info("HanTu Access Token 갱신 시작");
+
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+            Map<String, String> body = new HashMap<>();
+            body.put("grant_type", "client_credentials");
+            body.put("appkey", appKey);
+            body.put("appsecret", appSecret);
+
+            HttpEntity<Map<String, String>> request = new HttpEntity<>(body, httpHeaders);
+
+            ResponseEntity<ResponseTuzaAccessTokenDto> response = restTemplate.postForEntity(tokenUrl, request, ResponseTuzaAccessTokenDto.class);
+
+            if (response.getStatusCode() == HttpStatus.OK) {
+                apiTokenStore.saveAccessToken(response.getBody().getAccessToken());
+                log.info("HanTU Access Token 갱신 완료");
+                return true;
+            }
+
+            log.error("갱신 실패 - 응답이 잘못됨");
+            return false;
+        } catch (Exception e) {
+            log.error("갱신 중 오류 발생", e);
+            return false;
+        }
+    }
+
+    public String getCurrentAccessToken() {
+        return apiTokenStore.getAccessToken();
+    }
+}

--- a/src/main/java/naughty/tuzamate/global/config/WebConfig.java
+++ b/src/main/java/naughty/tuzamate/global/config/WebConfig.java
@@ -2,13 +2,21 @@ package naughty.tuzamate.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
+@EnableScheduling // 스케줄링 사용을 위해서
 public class WebConfig {
 
     @Bean
     public WebClient webClient() {
         return WebClient.builder().build();
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/naughty/tuzamate/global/config/WebConfig.java
+++ b/src/main/java/naughty/tuzamate/global/config/WebConfig.java
@@ -7,7 +7,6 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
-@EnableScheduling // 스케줄링 사용을 위해서
 public class WebConfig {
 
     @Bean

--- a/src/test/java/naughty/tuzamate/auth/hantu/service/ApiTokenServiceTest.java
+++ b/src/test/java/naughty/tuzamate/auth/hantu/service/ApiTokenServiceTest.java
@@ -1,0 +1,65 @@
+package naughty.tuzamate.auth.hantu.service;
+
+import naughty.tuzamate.auth.hantu.ApiTokenInMemoryStore;
+import naughty.tuzamate.auth.hantu.dto.ResponseTuzaAccessTokenDto;
+import naughty.tuzamate.auth.hantu.repository.ApiTokenStore;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+/*@TestPropertySource(properties = {
+        "APP_KEY=test-app-key",
+        "APP_SECRET_KEY=test-secret-key",
+        "URL=test_url"
+}) --> @ExtendWith 사용하면 적용이 되지 않는다. 그래서 ApiTokenService에서 생성자 주입을 적용하였다. */
+@ExtendWith(MockitoExtension.class)
+class ApiTokenServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    private ApiTokenService apiTokenService;
+    private ApiTokenStore apiTokenStore;
+
+    @BeforeEach
+    void before() {
+        apiTokenStore = new ApiTokenInMemoryStore();
+        apiTokenService = new ApiTokenService(apiTokenStore, restTemplate, "test-app-key", "test-secret-key", "test-url");
+    }
+
+    @Test
+    void 토큰X() {
+
+        String currentAccessToken = apiTokenService.getCurrentAccessToken();
+        assertThat(currentAccessToken).isNull();
+    }
+
+    @Test
+    void 액세스토큰갱신성공() {
+
+        // given
+        ResponseTuzaAccessTokenDto accessToeknResponse = ResponseTuzaAccessTokenDto.builder().accessToken("new-access-token").build();
+
+        // when
+        when(restTemplate.postForEntity(anyString(), any(), eq(ResponseTuzaAccessTokenDto.class)))
+                .thenReturn((ResponseEntity<ResponseTuzaAccessTokenDto>) new ResponseEntity<>(accessToeknResponse, HttpStatus.OK));
+
+        boolean result = apiTokenService.refreshAccessToken();
+
+        // then
+        assertThat(result).isTrue();
+        assertThat(apiTokenService.getCurrentAccessToken()).isEqualTo("new-access-token");
+
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #20 

## 📌 개요
- 인메모리 방식과 스케줄링을 사용하여 API에 접근할 수 있도록 해주는 엑세스 토큰을 발급 받는다
- 인메모리 방식 저장소를 택하였지만 확장성을 위해 저장소 인터페이스 구성

## 🔁 변경 사항
- WebConfig에 RestTemplate을 빈 주입
- auth에 hanTu 엑세스 토큰 관련 코드 작성
- 인메모리 방식 및 스케줄링

## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] PR에 적절한 라벨을 선택
- [x] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added management and secure in-memory storage of API access tokens with thread-safe access.
  - Introduced a service for refreshing and retrieving API tokens via scheduled daily updates.
  - Enabled scheduling support for automated token refresh tasks.
  - Added support for both synchronous and reactive HTTP client configurations.

- **Tests**
  - Added tests to verify API token storage and refresh functionality.

- **Chores**
  - Introduced new data transfer objects for access token responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->