### PR TITLE
[FEAT] 한국투자증권 코스피, 코스닥, 나스닥 주식 코드 저장 및 한투 액세스 키 발급 컨트롤러 수동 설정

### DIFF
--- a/src/main/java/naughty/tuzamate/auth/hantu/HantuApiTokenInMemoryStore.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/HantuApiTokenInMemoryStore.java
@@ -1,6 +1,6 @@
 package naughty.tuzamate.auth.hantu;
 
-import naughty.tuzamate.auth.hantu.repository.ApiTokenStore;
+import naughty.tuzamate.auth.hantu.repository.HantuApiTokenStore;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
@@ -9,7 +9,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 @Component
 @Primary
-public class ApiTokenInMemoryStore implements ApiTokenStore {
+public class HantuApiTokenInMemoryStore implements HantuApiTokenStore {
 
     private String accessToken;
     private final ReadWriteLock lock = new ReentrantReadWriteLock();

--- a/src/main/java/naughty/tuzamate/auth/hantu/HantuApiTokenRefreshScheduler.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/HantuApiTokenRefreshScheduler.java
@@ -4,7 +4,7 @@ package naughty.tuzamate.auth.hantu;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import naughty.tuzamate.auth.hantu.service.ApiTokenService;
+import naughty.tuzamate.auth.hantu.service.HantuApiTokenService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -21,9 +21,9 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @ConditionalOnProperty(name = "hantu.token.schedule.enabled", havingValue = "true")
 // @ConditionalOnProperty를 사용하여 개발 중에는 이 클래스가 실행되지 않도록 한다.
-public class ApiTokenRefreshScheduler {
+public class HantuApiTokenRefreshScheduler {
 
-     private final ApiTokenService apiTokenService;
+     private final HantuApiTokenService apiTokenService;
 
     @PostConstruct
     public void firstToken() {

--- a/src/main/java/naughty/tuzamate/auth/hantu/controller/HantuApiTokenController.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/controller/HantuApiTokenController.java
@@ -1,7 +1,9 @@
 package naughty.tuzamate.auth.hantu.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.hantu.error.HantuErrorCode;
 import naughty.tuzamate.auth.hantu.service.HantuApiTokenService;
 import naughty.tuzamate.global.apiPayload.CustomResponse;
 import naughty.tuzamate.global.success.GeneralSuccessCode;
@@ -10,15 +12,21 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Hantu API Token", description = "한국 투자 증권 액세스 키 발급 API")
 public class HantuApiTokenController {
 
     private final HantuApiTokenService hantuApiTokenService;
 
     @PostMapping("/hantu/accessToken")
-    @Tag(name = "한투 액세스 키 발급", description = "수동으로 한국 투자 증권 액세스 키 발급")
+    @Operation(summary = "한투 액세스 키 발급", description = "수동으로 한국 투자 증권 액세스 키 발급")
     public CustomResponse<?> getHantuzaAccessToken() {
 
         boolean result = hantuApiTokenService.refreshAccessToken();
-        return CustomResponse.onSuccess(GeneralSuccessCode.OK, "한국투자증권 액세스 키 발급 상태: "+result);
+
+        if (result) {
+            return CustomResponse.onSuccess(GeneralSuccessCode.OK, "한국투자증권 액세스 키 발급 성공");
+        } else {
+            return CustomResponse.onFail(HantuErrorCode.TOKEN_REFRESH_FAIL);
+        }
     }
 }

--- a/src/main/java/naughty/tuzamate/auth/hantu/controller/HantuApiTokenController.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/controller/HantuApiTokenController.java
@@ -1,0 +1,24 @@
+package naughty.tuzamate.auth.hantu.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.hantu.service.HantuApiTokenService;
+import naughty.tuzamate.global.apiPayload.CustomResponse;
+import naughty.tuzamate.global.success.GeneralSuccessCode;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class HantuApiTokenController {
+
+    private final HantuApiTokenService hantuApiTokenService;
+
+    @PostMapping("/hantu/accessToken")
+    @Tag(name = "한투 액세스 키 발급", description = "수동으로 한국 투자 증권 액세스 키 발급")
+    public CustomResponse<?> getHantuzaAccessToken() {
+
+        boolean result = hantuApiTokenService.refreshAccessToken();
+        return CustomResponse.onSuccess(GeneralSuccessCode.OK, "한국투자증권 액세스 키 발급 상태: "+result);
+    }
+}

--- a/src/main/java/naughty/tuzamate/auth/hantu/dto/ResponseHantuAccessTokenDto.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/dto/ResponseHantuAccessTokenDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class ResponseTuzaAccessTokenDto {
+public class ResponseHantuAccessTokenDto {
 
     private String accessToken;
     private String tokenType;

--- a/src/main/java/naughty/tuzamate/auth/hantu/error/HantuErrorCode.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/error/HantuErrorCode.java
@@ -1,0 +1,19 @@
+package naughty.tuzamate.auth.hantu.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import naughty.tuzamate.global.error.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum HantuErrorCode implements BaseErrorCode {
+
+    TOKEN_REFRESH_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "HANTU50001", "한국투자증권 액세스 키 갱신에 실패했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/naughty/tuzamate/auth/hantu/repository/HantuApiTokenStore.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/repository/HantuApiTokenStore.java
@@ -1,6 +1,6 @@
 package naughty.tuzamate.auth.hantu.repository;
 
-public interface ApiTokenStore {
+public interface HantuApiTokenStore {
 
     void saveAccessToken(String accessToken);
 

--- a/src/main/java/naughty/tuzamate/auth/hantu/service/HantuApiTokenService.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/service/HantuApiTokenService.java
@@ -1,8 +1,8 @@
 package naughty.tuzamate.auth.hantu.service;
 
 import lombok.extern.slf4j.Slf4j;
-import naughty.tuzamate.auth.hantu.dto.ResponseTuzaAccessTokenDto;
-import naughty.tuzamate.auth.hantu.repository.ApiTokenStore;
+import naughty.tuzamate.auth.hantu.dto.ResponseHantuAccessTokenDto;
+import naughty.tuzamate.auth.hantu.repository.HantuApiTokenStore;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -13,9 +13,9 @@ import java.util.Map;
 
 @Service
 @Slf4j
-public class ApiTokenService {
+public class HantuApiTokenService {
 
-    private final ApiTokenStore apiTokenStore;
+    private final HantuApiTokenStore apiTokenStore;
     private final RestTemplate restTemplate;
 
     //    @Value("${tuza.api.APP_KEY}")
@@ -27,7 +27,7 @@ public class ApiTokenService {
     //    @Value("${tuza.api.URL}")
     private final String tokenUrl;
 
-    public ApiTokenService(ApiTokenStore apiTokenStore, RestTemplate restTemplate, @Value("${tuza.api.APP_KEY}") String appKey, @Value("${tuza.api.APP_SECRET_KEY}") String appSecret, @Value("${tuza.api.URL}") String tokenUrl) {
+    public HantuApiTokenService(HantuApiTokenStore apiTokenStore, RestTemplate restTemplate, @Value("${tuza.api.APP_KEY}") String appKey, @Value("${tuza.api.APP_SECRET_KEY}") String appSecret, @Value("${tuza.api.URL}") String tokenUrl) {
         this.apiTokenStore = apiTokenStore;
         this.restTemplate = restTemplate;
         this.appKey = appKey;
@@ -50,7 +50,7 @@ public class ApiTokenService {
 
             HttpEntity<Map<String, String>> request = new HttpEntity<>(body, httpHeaders);
 
-            ResponseEntity<ResponseTuzaAccessTokenDto> response = restTemplate.postForEntity(tokenUrl, request, ResponseTuzaAccessTokenDto.class);
+            ResponseEntity<ResponseHantuAccessTokenDto> response = restTemplate.postForEntity(tokenUrl, request, ResponseHantuAccessTokenDto.class);
 
             if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
                 apiTokenStore.saveAccessToken(response.getBody().getAccessToken());

--- a/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
@@ -1,0 +1,28 @@
+package naughty.tuzamate.domain.stock.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.domain.stock.error.StockErrorCode;
+import naughty.tuzamate.domain.stock.service.StockService;
+import naughty.tuzamate.global.apiPayload.CustomResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StockController {
+
+    private final StockService stockService;
+
+    @PostMapping("/post-stock-codes")
+    @Tag(name = "코스피, 코스닥, 나스닥 주식 코드를 DB에 저장")
+    public CustomResponse<?> saveStockCodes() {
+
+        try {
+            stockService.codeSaveProcess();
+            return CustomResponse.onSuccess("주식 코드 저장 완료");
+        } catch (Exception e) {
+            return CustomResponse.onFail(StockErrorCode.STOCK_CODE_SAVE_ERROR);
+        }
+    }
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
@@ -2,6 +2,7 @@ package naughty.tuzamate.domain.stock.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import naughty.tuzamate.domain.stock.error.StockErrorCode;
 import naughty.tuzamate.domain.stock.service.StockService;
 import naughty.tuzamate.global.apiPayload.CustomResponse;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class StockController {
 
     private final StockService stockService;
@@ -22,6 +24,7 @@ public class StockController {
             stockService.codeSaveProcess();
             return CustomResponse.onSuccess("주식 코드 저장 완료");
         } catch (Exception e) {
+            log.error("주식 코드 저장 중 오류 발생: {}", e.getMessage(), e);
             return CustomResponse.onFail(StockErrorCode.STOCK_CODE_SAVE_ERROR);
         }
     }

--- a/src/main/java/naughty/tuzamate/domain/stock/entity/NasdaqStockCode.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/entity/NasdaqStockCode.java
@@ -1,0 +1,24 @@
+package naughty.tuzamate.domain.stock.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+// 미국 주식 코드 엔티티 (나스닥)
+public class NasdaqStockCode {
+
+    @Id
+    private String code;
+
+    public static NasdaqStockCode of(String code) {
+        return new NasdaqStockCode(code);
+    }
+
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/entity/StockCode.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/entity/StockCode.java
@@ -1,0 +1,24 @@
+package naughty.tuzamate.domain.stock.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+// 한국 주식 코드 엔티티 (코스피, 코스닥)
+public class StockCode {
+
+    @Id
+    private String code;
+
+    public static StockCode of(String code) {
+        return new StockCode(code);
+    }
+
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/error/StockErrorCode.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/error/StockErrorCode.java
@@ -1,0 +1,19 @@
+package naughty.tuzamate.domain.stock.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import naughty.tuzamate.global.error.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum StockErrorCode implements BaseErrorCode {
+
+    STOCK_CODE_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "STOCK50001", "주식 코드 저장에 실패했습니다."),
+    ;
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/error/exception/StockCustomException.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/error/exception/StockCustomException.java
@@ -1,0 +1,11 @@
+package naughty.tuzamate.domain.stock.error.exception;
+
+import naughty.tuzamate.global.error.BaseErrorCode;
+import naughty.tuzamate.global.error.exception.CustomException;
+
+public class StockCustomException extends CustomException {
+
+    public StockCustomException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/repository/NasdaqCodeRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/repository/NasdaqCodeRepository.java
@@ -3,5 +3,5 @@ package naughty.tuzamate.domain.stock.repository;
 import naughty.tuzamate.domain.stock.entity.NasdaqStockCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NasdaqCodeRepository extends JpaRepository<NasdaqStockCode, Long> {
+public interface NasdaqCodeRepository extends JpaRepository<NasdaqStockCode, String> {
 }

--- a/src/main/java/naughty/tuzamate/domain/stock/repository/NasdaqCodeRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/repository/NasdaqCodeRepository.java
@@ -1,0 +1,7 @@
+package naughty.tuzamate.domain.stock.repository;
+
+import naughty.tuzamate.domain.stock.entity.NasdaqStockCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NasdaqCodeRepository extends JpaRepository<NasdaqStockCode, Long> {
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/repository/StockCodeRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/repository/StockCodeRepository.java
@@ -1,0 +1,7 @@
+package naughty.tuzamate.domain.stock.repository;
+
+import naughty.tuzamate.domain.stock.entity.StockCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockCodeRepository extends JpaRepository<StockCode, String> {
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/service/StockService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/StockService.java
@@ -1,0 +1,193 @@
+package naughty.tuzamate.domain.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.domain.stock.entity.NasdaqStockCode;
+import naughty.tuzamate.domain.stock.entity.StockCode;
+import naughty.tuzamate.domain.stock.repository.NasdaqCodeRepository;
+import naughty.tuzamate.domain.stock.repository.StockCodeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.*;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StockService {
+
+    private final StockCodeRepository stockCodeRepository;
+    private final NasdaqCodeRepository nasdaqCodeRepository;
+
+
+     // 한국투자증권의 자료를 이용해서 코스피, 코스닥, 나스닥 주식 코드를 DB에 저장하는 메소드
+    public void codeSaveProcess() throws IOException{
+
+        stockCodeRepository.deleteAll();
+
+        String kospiZipUrl = "https://new.real.download.dws.co.kr/common/master/kospi_code.mst.zip";
+        String kosdaqZipUrl = "https://new.real.download.dws.co.kr/common/master/kosdaq_code.mst.zip";
+        String nasdaqZipUrl = "https://new.real.download.dws.co.kr/common/master/nasmst.cod.zip";
+
+
+        /*String kospiZipPath = "C:\\Users\\namju\\Desktop\\기타 프젝\\주식 저장소\\kospi_code.mst.zip";
+        String kosdaqZipPath = "C:\\Users\\namju\\Desktop\\기타 프젝\\주식 저장소\\kosdaq_code.mst.zip";
+        String nasdaqZipPath = "C:\\Users\\namju\\Desktop\\기타 프젝\\주식 저장소\\nasmst.cod.zip";
+
+        String extractDir = "/stockcodes/";
+        String kospiTxtFileName = "kospi_code.mst";
+        String kosdaqTxtFileName = "kosdaq_code.mst";
+        String nasdaqTxtFileName = "nasmst.cod";
+
+        download(kospiZipUrl, kospiZipPath);
+        unzip(kospiZipPath, extractDir);
+        List<String> kospiStockCodes = extractStockCode(extractDir + kospiTxtFileName);
+        saveStockCodes(kospiStockCodes);
+
+        download(kosdaqZipUrl, kosdaqZipPath);
+        unzip(kosdaqZipPath, extractDir);
+        List<String> kosdaqStockCodes = extractStockCode(extractDir + kosdaqTxtFileName);
+        saveStockCodes(kosdaqStockCodes);
+
+        download(nasdaqZipUrl, nasdaqZipPath);
+        unzip(nasdaqZipPath, extractDir);
+        List<String> nasdaqStockCodes = extractNasdaqStockCode(extractDir + nasdaqTxtFileName);
+        saveNasdaqStockCodes(nasdaqStockCodes);*/
+
+
+        String baseDir = "/home/ubuntu/stockcodes";
+        Path extractDir = Paths.get(baseDir);
+        Files.createDirectories(extractDir); // 없으면 생성
+
+        Path kospiZipPath = extractDir.resolve("kospi_code.mst.zip");
+        Path kosdaqZipPath = extractDir.resolve("kosdaq_code.mst.zip");
+        Path nasdaqZipPath = extractDir.resolve("nasmst.cod.zip");
+
+        download(kospiZipUrl, kospiZipPath.toString());
+        unzip(kospiZipPath.toString(), extractDir.toString());
+        List<String> kospiStockCodes = extractStockCode(extractDir.resolve("kospi_code.mst").toString());
+        saveStockCodes(kospiStockCodes);
+
+        download(kosdaqZipUrl, kosdaqZipPath.toString());
+        unzip(kosdaqZipPath.toString(), extractDir.toString());
+        List<String> kosdaqStockCodes = extractStockCode(extractDir.resolve("kosdaq_code.mst").toString());
+        saveStockCodes(kosdaqStockCodes);
+
+        download(nasdaqZipUrl, nasdaqZipPath.toString());
+        unzip(nasdaqZipPath.toString(), extractDir.toString());
+        List<String> nasdaqStockCodes = extractNasdaqStockCode(extractDir.resolve("nasmst.cod").toString());
+        saveNasdaqStockCodes(nasdaqStockCodes);
+
+    }
+
+    public void saveNasdaqStockCodes(List<String> codes) {
+        for (String code : codes) {
+            nasdaqCodeRepository.save(NasdaqStockCode.of(code));
+        }
+    }
+
+    public void saveStockCodes(List<String> codes) {
+        for (String code : codes) {
+            stockCodeRepository.save(StockCode.of(code));
+        }
+    }
+
+    /**
+     * zip 파일 다운로드
+     * zip 압축 해제 후 TXT 파일 추출
+     * 각 줄의 맨 앞 6자리 주식 코드 추출 - 코스피, 코스닥
+     * DB에 저장
+     */
+
+    public void download(String urlInfo, String destFile) throws IOException {
+
+        URL url = new URL(urlInfo);
+        ReadableByteChannel rbc = Channels.newChannel(url.openStream());
+
+        FileOutputStream fos = new FileOutputStream(destFile);
+        fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+
+        fos.close();
+        rbc.close();
+
+    }
+
+    public void unzip(String zipFilePath, String destDir) throws IOException {
+
+        File dir = new File(destDir);
+
+        if (!dir.exists()) dir.mkdir();
+        byte[] buffer = new byte[1024];
+
+        ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFilePath));
+        ZipEntry zipEntry = zis.getNextEntry();
+
+        while (zipEntry != null) {
+            File newFile = new File(destDir, zipEntry.getName());
+            FileOutputStream fos = new FileOutputStream(newFile);
+            int len;
+
+            while ((len = zis.read(buffer)) > 0) {
+                fos.write(buffer, 0, len);
+            }
+            fos.close();
+            zipEntry = zis.getNextEntry();
+        }
+
+        zis.closeEntry();
+        zis.close();
+    }
+
+    public List<String> extractStockCode(String txtFilePath) throws IOException {
+
+        List<String> codes = new ArrayList<>();
+        BufferedReader br = new BufferedReader(new FileReader(txtFilePath));
+
+        String line;
+        // 평범한 주식이 아닌 것은 제외시킨다
+        while ((line = br.readLine()) != null) {
+            if (line.startsWith("F")) continue;
+            else if (line.startsWith("Q")) {
+                String code = line.substring(0, 7).trim();
+                codes.add(code);
+            }
+            else if (line.startsWith("J")) {
+                String code = line.substring(1, 7).trim();
+                codes.add(code);
+            }
+            else if (line.length() >= 6) {
+                String code = line.substring(0, 6).trim();
+                codes.add(code);
+            }
+        }
+        br.close();
+        return codes;
+    }
+
+    // 나스닥의 주식코드는 한국과 달라 따로 구성한다
+    public List<String> extractNasdaqStockCode(String txtFilePath) throws IOException {
+
+        List<String> codes = new ArrayList<>();
+        BufferedReader br = new BufferedReader(new FileReader(txtFilePath));
+
+        String line;
+        while ((line = br.readLine()) != null) {
+            String[] tokens = line.split("\t");
+
+            if (tokens.length >= 5) {
+                codes.add(tokens[4]);
+            }
+        }
+        br.close();
+        return codes;
+    }
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/service/StockService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/StockService.java
@@ -1,6 +1,7 @@
 package naughty.tuzamate.domain.stock.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import naughty.tuzamate.domain.stock.entity.NasdaqStockCode;
 import naughty.tuzamate.domain.stock.entity.StockCode;
 import naughty.tuzamate.domain.stock.repository.NasdaqCodeRepository;
@@ -23,6 +24,7 @@ import java.util.zip.ZipInputStream;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class StockService {
 
     private final StockCodeRepository stockCodeRepository;
@@ -39,7 +41,7 @@ public class StockService {
         String nasdaqZipUrl = "https://new.real.download.dws.co.kr/common/master/nasmst.cod.zip";
 
 
-        /*String kospiZipPath = "C:\\Users\\namju\\Desktop\\기타 프젝\\주식 저장소\\kospi_code.mst.zip";
+      /*  String kospiZipPath = "C:\\Users\\namju\\Desktop\\기타 프젝\\주식 저장소\\kospi_code.mst.zip";
         String kosdaqZipPath = "C:\\Users\\namju\\Desktop\\기타 프젝\\주식 저장소\\kosdaq_code.mst.zip";
         String nasdaqZipPath = "C:\\Users\\namju\\Desktop\\기타 프젝\\주식 저장소\\nasmst.cod.zip";
 
@@ -84,7 +86,7 @@ public class StockService {
 
         download(nasdaqZipUrl, nasdaqZipPath.toString());
         unzip(nasdaqZipPath.toString(), extractDir.toString());
-        List<String> nasdaqStockCodes = extractNasdaqStockCode(extractDir.resolve("nasmst.cod").toString());
+        List<String> nasdaqStockCodes = extractNasdaqStockCode(extractDir.resolve("NASMST.CODd").toString());
         saveNasdaqStockCodes(nasdaqStockCodes);
 
     }
@@ -109,6 +111,8 @@ public class StockService {
      */
 
     public void download(String urlInfo, String destFile) throws IOException {
+        
+        log.info("다운로드 시작: {}", urlInfo);
 
         URL url = new URL(urlInfo);
         ReadableByteChannel rbc = Channels.newChannel(url.openStream());
@@ -118,6 +122,8 @@ public class StockService {
 
         fos.close();
         rbc.close();
+
+        log.info("다운로드 완료: {}", destFile);
 
     }
 

--- a/src/main/java/naughty/tuzamate/domain/stock/service/StockService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/StockService.java
@@ -111,19 +111,21 @@ public class StockService {
      */
 
     public void download(String urlInfo, String destFile) throws IOException {
-        
+
         log.info("다운로드 시작: {}", urlInfo);
 
         URL url = new URL(urlInfo);
-        ReadableByteChannel rbc = Channels.newChannel(url.openStream());
 
-        FileOutputStream fos = new FileOutputStream(destFile);
-        fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+        try (ReadableByteChannel rbc = Channels.newChannel(url.openStream());
+            FileOutputStream fos = new FileOutputStream(destFile)){
+            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
 
-        fos.close();
-        rbc.close();
+            log.info("다운로드 완료: {}", destFile);
+        }
 
-        log.info("다운로드 완료: {}", destFile);
+
+
+
 
     }
 
@@ -132,9 +134,38 @@ public class StockService {
         File dir = new File(destDir);
 
         if (!dir.exists()) dir.mkdir();
-        byte[] buffer = new byte[1024];
 
-        ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFilePath));
+        Path destDirPath = dir.toPath().normalize();
+
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFilePath))) {
+            ZipEntry zipEntry;
+            byte[] buffer = new byte[8192];
+
+            while ((zipEntry = zis.getNextEntry()) != null) {
+                Path entryPath = destDirPath.resolve(zipEntry.getName()).normalize();
+
+                if (!entryPath.startsWith(destDirPath)) {
+                    throw new IOException("Invalid zip entry: " + zipEntry.getName());
+                }
+
+                File newFile = entryPath.toFile();
+
+                try (FileOutputStream fos = new FileOutputStream(newFile)) {
+                        int len;
+                        while ((len = zis.read(buffer)) > 0) {
+                            fos.write(buffer, 0, len);
+                        }
+                    }
+                }
+                zis.closeEntry();
+            }
+        }
+
+//        byte[] buffer = new byte[1024];
+
+
+
+        /*ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFilePath));
         ZipEntry zipEntry = zis.getNextEntry();
 
         while (zipEntry != null) {
@@ -150,32 +181,30 @@ public class StockService {
         }
 
         zis.closeEntry();
-        zis.close();
-    }
+        zis.close();*/
 
     public List<String> extractStockCode(String txtFilePath) throws IOException {
 
         List<String> codes = new ArrayList<>();
-        BufferedReader br = new BufferedReader(new FileReader(txtFilePath));
-
-        String line;
-        // 평범한 주식이 아닌 것은 제외시킨다
-        while ((line = br.readLine()) != null) {
-            if (line.startsWith("F")) continue;
-            else if (line.startsWith("Q")) {
-                String code = line.substring(0, 7).trim();
-                codes.add(code);
-            }
-            else if (line.startsWith("J")) {
-                String code = line.substring(1, 7).trim();
-                codes.add(code);
-            }
-            else if (line.length() >= 6) {
-                String code = line.substring(0, 6).trim();
-                codes.add(code);
+        try(BufferedReader br = new BufferedReader(new FileReader(txtFilePath))) {
+            String line;
+            // 평범한 주식이 아닌 것은 제외시킨다
+            while ((line = br.readLine()) != null) {
+                if (line.startsWith("F")) continue;
+                else if (line.startsWith("Q")) {
+                    String code = line.substring(0, 7).trim();
+                    codes.add(code);
+                }
+                else if (line.startsWith("J")) {
+                    String code = line.substring(1, 7).trim();
+                    codes.add(code);
+                }
+                else if (line.length() >= 6) {
+                    String code = line.substring(0, 6).trim();
+                    codes.add(code);
+                }
             }
         }
-        br.close();
         return codes;
     }
 
@@ -183,17 +212,17 @@ public class StockService {
     public List<String> extractNasdaqStockCode(String txtFilePath) throws IOException {
 
         List<String> codes = new ArrayList<>();
-        BufferedReader br = new BufferedReader(new FileReader(txtFilePath));
 
-        String line;
-        while ((line = br.readLine()) != null) {
-            String[] tokens = line.split("\t");
+        try(BufferedReader br = new BufferedReader(new FileReader(txtFilePath));) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                String[] tokens = line.split("\t");
 
-            if (tokens.length >= 5) {
-                codes.add(tokens[4]);
+                if (tokens.length >= 5) {
+                    codes.add(tokens[4]);
+                }
             }
         }
-        br.close();
         return codes;
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/stock/service/StockService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/StockService.java
@@ -86,7 +86,7 @@ public class StockService {
 
         download(nasdaqZipUrl, nasdaqZipPath.toString());
         unzip(nasdaqZipPath.toString(), extractDir.toString());
-        List<String> nasdaqStockCodes = extractNasdaqStockCode(extractDir.resolve("NASMST.CODd").toString());
+        List<String> nasdaqStockCodes = extractNasdaqStockCode(extractDir.resolve("NASMST.COD").toString());
         saveNasdaqStockCodes(nasdaqStockCodes);
 
     }

--- a/src/test/java/naughty/tuzamate/auth/hantu/service/ApiTokenServiceTest.java
+++ b/src/test/java/naughty/tuzamate/auth/hantu/service/ApiTokenServiceTest.java
@@ -1,9 +1,8 @@
 package naughty.tuzamate.auth.hantu.service;
 
-import naughty.tuzamate.auth.hantu.ApiTokenInMemoryStore;
-import naughty.tuzamate.auth.hantu.dto.ResponseTuzaAccessTokenDto;
-import naughty.tuzamate.auth.hantu.repository.ApiTokenStore;
-import org.assertj.core.api.Assertions;
+import naughty.tuzamate.auth.hantu.HantuApiTokenInMemoryStore;
+import naughty.tuzamate.auth.hantu.dto.ResponseHantuAccessTokenDto;
+import naughty.tuzamate.auth.hantu.repository.HantuApiTokenStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
@@ -29,13 +27,13 @@ class ApiTokenServiceTest {
     @Mock
     private RestTemplate restTemplate;
 
-    private ApiTokenService apiTokenService;
-    private ApiTokenStore apiTokenStore;
+    private HantuApiTokenService apiTokenService;
+    private HantuApiTokenStore apiTokenStore;
 
     @BeforeEach
     void before() {
-        apiTokenStore = new ApiTokenInMemoryStore();
-        apiTokenService = new ApiTokenService(apiTokenStore, restTemplate, "test-app-key", "test-secret-key", "test-url");
+        apiTokenStore = new HantuApiTokenInMemoryStore();
+        apiTokenService = new HantuApiTokenService(apiTokenStore, restTemplate, "test-app-key", "test-secret-key", "test-url");
     }
 
     @Test
@@ -49,11 +47,11 @@ class ApiTokenServiceTest {
     void 액세스토큰갱신성공() {
 
         // given
-        ResponseTuzaAccessTokenDto accessToeknResponse = ResponseTuzaAccessTokenDto.builder().accessToken("new-access-token").build();
+        ResponseHantuAccessTokenDto accessToeknResponse = ResponseHantuAccessTokenDto.builder().accessToken("new-access-token").build();
 
         // when
-        when(restTemplate.postForEntity(anyString(), any(), eq(ResponseTuzaAccessTokenDto.class)))
-                .thenReturn((ResponseEntity<ResponseTuzaAccessTokenDto>) new ResponseEntity<>(accessToeknResponse, HttpStatus.OK));
+        when(restTemplate.postForEntity(anyString(), any(), eq(ResponseHantuAccessTokenDto.class)))
+                .thenReturn((ResponseEntity<ResponseHantuAccessTokenDto>) new ResponseEntity<>(accessToeknResponse, HttpStatus.OK));
 
         boolean result = apiTokenService.refreshAccessToken();
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🏷️ 관련 이슈
액세스 키 발급 수동 : 38ced1ba5c1f62d49303b7d34c527a3f74db2563
한투 주식 코드 저장 : 7cc3710c31d8891cc17eff289957e104efb2ac4b

## 📌 개요
- 한투 액세스 키 발급 수동
- 한투 주식 코드 저장

## 🔁 변경 사항

## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API endpoint to manually issue a Korean investment securities access token.
  * Introduced API endpoint for saving stock codes for KOSPI, KOSDAQ, and NASDAQ markets.
  * Added entities and repositories for managing Korean and NASDAQ stock codes.
  * Implemented service for batch downloading, extracting, and saving stock codes from external sources.
  * Introduced custom error handling for stock code operations.
  * Added error codes specific to the "Hantu" authentication module.

* **Refactor**
  * Renamed several classes, interfaces, and DTOs to follow a consistent "Hantu" naming convention for API token management.

* **Tests**
  * Updated test classes to align with the new "Hantu" naming convention for API token services and DTOs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->