### PR TITLE
[FEAT] : 나스닥 주식 정보를 가져오고 저장

### DIFF
--- a/src/main/java/naughty/tuzamate/auth/hantu/dto/ResponseHantuAccessTokenDto.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/dto/ResponseHantuAccessTokenDto.java
@@ -1,5 +1,6 @@
 package naughty.tuzamate.auth.hantu.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,9 +8,16 @@ import lombok.Getter;
 @Builder
 public class ResponseHantuAccessTokenDto {
 
-    private String access_token;
-    private String token_type;
-    private Long expires_in;
-    private String access_token_token_expired;
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+
+    @JsonProperty("access_token_token_expired")
+    private String accessTokenTokenExpired;
 
 }

--- a/src/main/java/naughty/tuzamate/auth/hantu/dto/ResponseHantuAccessTokenDto.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/dto/ResponseHantuAccessTokenDto.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 @Builder
 public class ResponseHantuAccessTokenDto {
 
-    private String accessToken;
-    private String tokenType;
-    private Long expiresIn;
-    private String accessTokenTokenExpired;
+    private String access_token;
+    private String token_type;
+    private Long expires_in;
+    private String access_token_token_expired;
 
 }

--- a/src/main/java/naughty/tuzamate/auth/hantu/service/HantuApiTokenService.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/service/HantuApiTokenService.java
@@ -53,7 +53,7 @@ public class HantuApiTokenService {
             ResponseEntity<ResponseHantuAccessTokenDto> response = restTemplate.postForEntity(tokenUrl, request, ResponseHantuAccessTokenDto.class);
 
             if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
-                apiTokenStore.saveAccessToken(response.getBody().getAccessToken());
+                apiTokenStore.saveAccessToken(response.getBody().getAccess_token());
                 log.info("HanTU Access Token 갱신 완료");
                 return true;
             }

--- a/src/main/java/naughty/tuzamate/auth/hantu/service/HantuApiTokenService.java
+++ b/src/main/java/naughty/tuzamate/auth/hantu/service/HantuApiTokenService.java
@@ -53,7 +53,7 @@ public class HantuApiTokenService {
             ResponseEntity<ResponseHantuAccessTokenDto> response = restTemplate.postForEntity(tokenUrl, request, ResponseHantuAccessTokenDto.class);
 
             if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
-                apiTokenStore.saveAccessToken(response.getBody().getAccess_token());
+                apiTokenStore.saveAccessToken(response.getBody().getAccessToken());
                 log.info("HanTU Access Token 갱신 완료");
                 return true;
             }

--- a/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
@@ -1,31 +1,57 @@
 package naughty.tuzamate.domain.stock.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import naughty.tuzamate.domain.stock.dto.NasdaqDto;
 import naughty.tuzamate.domain.stock.error.StockErrorCode;
-import naughty.tuzamate.domain.stock.service.StockService;
+import naughty.tuzamate.domain.stock.service.NasdaqService;
+import naughty.tuzamate.domain.stock.service.StockCodeService;
 import naughty.tuzamate.global.apiPayload.CustomResponse;
+import naughty.tuzamate.global.success.GeneralSuccessCode;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "주식 관련 API", description = "주식 코드 저장 및 관련 작업을 수행하는 API")
+@RequestMapping("/api")
 public class StockController {
 
-    private final StockService stockService;
+    private final StockCodeService stockCodeService;
+    private final NasdaqService nasdaqService;
 
     @PostMapping("/post-stock-codes")
-    @Tag(name = "코스피, 코스닥, 나스닥 주식 코드를 DB에 저장")
+    @Operation(summary = "주식 코드 저장", description = "코스피, 코스닥, 나스닥 주식 코드를 저장합니다.")
     public CustomResponse<?> saveStockCodes() {
 
         try {
-            stockService.codeSaveProcess();
+            stockCodeService.codeSaveProcess();
             return CustomResponse.onSuccess("주식 코드 저장 완료");
         } catch (Exception e) {
             log.error("주식 코드 저장 중 오류 발생: {}", e.getMessage(), e);
             return CustomResponse.onFail(StockErrorCode.STOCK_CODE_SAVE_ERROR);
         }
+    }
+
+    @PostMapping("/nasdaq/{nasdaqStockCode}")
+    @Operation(summary = "수동으로 나스닥 주식 한 개의 기본 정보 가져오기",
+            description = "나스닥 주식 한 개의 기본 정보를 가져옵니다. 주식 코드를 입력해야 합니다.")
+    public NasdaqDto.NasdaqInfoDto getNasdaqStockInfo(@PathVariable("nasdaqStockCode") String nasdaqStockCode) {
+
+        return nasdaqService.getCurrentNasdaqInfo(nasdaqStockCode);
+    }
+
+    @PostMapping("/nasdaq/all")
+    @Operation(summary = "나스닥 주식 전체 정보 가져오기",
+            description = "나스닥 주식 전체 정보를 가져오고 저장합니다. 주식 코드를 입력하지 않아도 됩니다.")
+    public CustomResponse<?> getAllNasdaqStockInfo() {
+
+        nasdaqService.saveNasdaqStocksInfo();
+        return CustomResponse.onSuccess(GeneralSuccessCode.CREATED, "나스닥 주식 전체 정보 저장 완료");
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/stock/dto/NasdaqDto.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/dto/NasdaqDto.java
@@ -1,0 +1,30 @@
+package naughty.tuzamate.domain.stock.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import naughty.tuzamate.domain.stock.entity.NasdaqStockInfo;
+
+public class NasdaqDto {
+
+  @Setter
+  @Getter
+  public static class NasdaqInfoDto {
+
+    private String code;
+    private String perx; // PER
+    private String pbrx; // PBR
+    private String epsx; // EPS
+    private String e_icod; // 업종 섹터
+
+    public NasdaqStockInfo toEntity( NasdaqDto.NasdaqInfoDto dto) {
+      return NasdaqStockInfo.builder()
+              .code(dto.code)
+              .perx(dto.perx)
+              .pbrx(dto.pbrx)
+              .epsx(dto.epsx)
+              .eIcod(dto.e_icod)
+              .build();
+    }
+  }
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/entity/NasdaqStockInfo.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/entity/NasdaqStockInfo.java
@@ -1,0 +1,25 @@
+package naughty.tuzamate.domain.stock.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class NasdaqStockInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String code;
+    private String perx; // PER
+    private String pbrx; // PBR
+    private String epsx; // EPS
+    private String eIcod; // 업종 섹터
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/repository/NasdaqStockInfoRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/repository/NasdaqStockInfoRepository.java
@@ -1,0 +1,7 @@
+package naughty.tuzamate.domain.stock.repository;
+
+import naughty.tuzamate.domain.stock.entity.NasdaqStockInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NasdaqStockInfoRepository extends JpaRepository<NasdaqStockInfo, Long> {
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/repository/code/NasdaqCodeRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/repository/code/NasdaqCodeRepository.java
@@ -1,4 +1,4 @@
-package naughty.tuzamate.domain.stock.repository;
+package naughty.tuzamate.domain.stock.repository.code;
 
 import naughty.tuzamate.domain.stock.entity.NasdaqStockCode;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/naughty/tuzamate/domain/stock/repository/code/StockCodeRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/repository/code/StockCodeRepository.java
@@ -1,4 +1,4 @@
-package naughty.tuzamate.domain.stock.repository;
+package naughty.tuzamate.domain.stock.repository.code;
 
 import naughty.tuzamate.domain.stock.entity.StockCode;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/naughty/tuzamate/domain/stock/service/NasdaqService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/NasdaqService.java
@@ -105,7 +105,7 @@ public class NasdaqService {
     public void saveNasdaqStocksInfo() {
         List<NasdaqStockCode> stockCodeList = nasdaqCodeRepository.findAll();
 
-        nasdaqStockInfoRepository.deleteAll();
+        nasdaqStockInfoRepository.deleteAllInBatch();
 
         for (NasdaqStockCode stockCode : stockCodeList) {
             try {

--- a/src/main/java/naughty/tuzamate/domain/stock/service/NasdaqService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/NasdaqService.java
@@ -1,0 +1,136 @@
+package naughty.tuzamate.domain.stock.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import naughty.tuzamate.auth.hantu.service.HantuApiTokenService;
+import naughty.tuzamate.domain.stock.dto.NasdaqDto;
+import naughty.tuzamate.domain.stock.entity.NasdaqStockCode;
+import naughty.tuzamate.domain.stock.entity.NasdaqStockInfo;
+import naughty.tuzamate.domain.stock.repository.NasdaqStockInfoRepository;
+import naughty.tuzamate.domain.stock.repository.code.NasdaqCodeRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NasdaqService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final NasdaqCodeRepository nasdaqCodeRepository;
+    private final NasdaqStockInfoRepository nasdaqStockInfoRepository;
+    private final HantuApiTokenService hantuApiTokenService;
+
+    @Value("${tuza.api.APP_KEY}")
+    private String appKey;
+
+    @Value("${tuza.api.APP_SECRET_KEY}")
+    private String appSecret;
+
+    private String accessToken;
+
+    private HttpHeaders createHeaders() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        accessToken = hantuApiTokenService.getCurrentAccessToken();
+
+        httpHeaders.setBearerAuth(accessToken);
+        httpHeaders.set("appkey", appKey);
+        httpHeaders.set("appsecret", appSecret);
+        httpHeaders.set("tr_id", "HHDFS76200200");
+        httpHeaders.set("custtype", "P");
+
+        return httpHeaders;
+    }
+
+    private NasdaqDto.NasdaqInfoDto parsingCurrentNasdaqInfo(String response, String stockCode) {
+        NasdaqDto.NasdaqInfoDto data = new NasdaqDto.NasdaqInfoDto();
+
+        try {
+            JsonNode rootNode = objectMapper.readTree(response);
+            JsonNode node = rootNode.path("output");
+
+            if (node != null) {
+                NasdaqDto.NasdaqInfoDto outputDto = new NasdaqDto.NasdaqInfoDto();
+
+                outputDto.setCode(stockCode);
+                outputDto.setPerx(node.path("perx").asText());
+                outputDto.setPbrx(node.path("pbrx").asText());
+                outputDto.setEpsx(node.path("epsx").asText());
+                if (node.path("e_icod").asText().isEmpty()) outputDto.setE_icod(null);
+                else outputDto.setE_icod(node.path("e_icod").asText());
+
+                data = outputDto;
+            }
+            return data;
+        } catch (Exception e) {
+            log.error("error is : {}", e.getMessage());
+            throw new RuntimeException();
+        }
+    }
+
+    public NasdaqDto.NasdaqInfoDto getCurrentNasdaqInfo(String stockCode) {
+
+
+        HttpHeaders header = createHeaders();
+
+        String url = "https://openapi.koreainvestment.com:9443/uapi/overseas-price/v1/quotations/price-detail";
+
+        HttpEntity<?> httpEntity = new HttpEntity<>(header);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url)
+                .queryParam("AUTH", "")
+                .queryParam("EXCD", "NAS")
+                .queryParam("SYMB", stockCode);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                builder.toUriString(),
+                HttpMethod.GET,
+                httpEntity,
+                String.class
+        );
+
+        return parsingCurrentNasdaqInfo(response.getBody(), stockCode);
+
+    }
+
+    public void saveNasdaqStocksInfo() {
+        List<NasdaqStockCode> stockCodeList = nasdaqCodeRepository.findAll();
+
+        nasdaqStockInfoRepository.deleteAll();
+
+        for (NasdaqStockCode stockCode : stockCodeList) {
+            try {
+
+                Thread.sleep(100);
+
+                NasdaqDto.NasdaqInfoDto currentNasdaqInfo = getCurrentNasdaqInfo(stockCode.getCode());
+
+               /* log.info("PER: {}", currentNasdaqInfo.getPerx());
+                log.info("EPS: {}", currentNasdaqInfo.getEpsx());*/
+
+                NasdaqStockInfo entity = currentNasdaqInfo.toEntity(currentNasdaqInfo);
+
+                nasdaqStockInfoRepository.save(entity);
+
+                log.info("Saved stocks is : {}", stockCode.getCode());
+
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt(); // 현재 스레드 인터럽트 상태 복구
+                log.info("Thread Interrupted : {}", e.getMessage());
+                break;
+            } catch (Exception e) {
+                log.info("Error stock code is {} : {} and pass!", stockCode.getCode(), e.getMessage());
+            }
+
+        }
+    }
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/service/StockCodeService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/StockCodeService.java
@@ -34,7 +34,7 @@ public class StockCodeService {
      // 한국투자증권의 자료를 이용해서 코스피, 코스닥, 나스닥 주식 코드를 DB에 저장하는 메소드
     public void codeSaveProcess() throws IOException{
 
-        stockCodeRepository.deleteAll();
+        stockCodeRepository.deleteAllInBatch();
 
         String kospiZipUrl = "https://new.real.download.dws.co.kr/common/master/kospi_code.mst.zip";
         String kosdaqZipUrl = "https://new.real.download.dws.co.kr/common/master/kosdaq_code.mst.zip";

--- a/src/main/java/naughty/tuzamate/domain/stock/service/StockCodeService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/StockCodeService.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import naughty.tuzamate.domain.stock.entity.NasdaqStockCode;
 import naughty.tuzamate.domain.stock.entity.StockCode;
-import naughty.tuzamate.domain.stock.repository.NasdaqCodeRepository;
-import naughty.tuzamate.domain.stock.repository.StockCodeRepository;
+import naughty.tuzamate.domain.stock.repository.code.NasdaqCodeRepository;
+import naughty.tuzamate.domain.stock.repository.code.StockCodeRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +25,7 @@ import java.util.zip.ZipInputStream;
 @RequiredArgsConstructor
 @Transactional
 @Slf4j
-public class StockService {
+public class StockCodeService {
 
     private final StockCodeRepository stockCodeRepository;
     private final NasdaqCodeRepository nasdaqCodeRepository;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #29 

## 📌 개요
- DB에 있는 나스닥 코드를 이용해 주식 정보를 가져오고 저장한다.

## 🔁 변경 사항
173f51632f661a8c8921c850c4cb569685c27aa5
## 📸 스크린샷

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하는지 확인
- [ ] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoints to fetch and save Nasdaq stock information, including retrieving details for a specific stock and saving all stock data.
  * Introduced new data structures, entity, repository, and services to support Nasdaq stock information management.

* **Refactor**
  * Updated field naming conventions to use snake_case for improved consistency.
  * Replaced the stock service dependency with more specific services for stock code and Nasdaq data handling.
  * Improved API documentation annotations for clarity.

* **Chores**
  * Organized repository classes into subpackages for better code structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->