### PR TITLE
[FEAT] 한국 주식(코스피, 코스닥) 정보 저장

### DIFF
--- a/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
@@ -4,10 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import naughty.tuzamate.domain.stock.dto.NasdaqDto;
+import naughty.tuzamate.domain.stock.dto.krx.KrxDto;
+import naughty.tuzamate.domain.stock.dto.nasdaq.NasdaqDto;
 import naughty.tuzamate.domain.stock.error.StockErrorCode;
-import naughty.tuzamate.domain.stock.service.NasdaqService;
-import naughty.tuzamate.domain.stock.service.StockCodeService;
+import naughty.tuzamate.domain.stock.service.*;
 import naughty.tuzamate.global.apiPayload.CustomResponse;
 import naughty.tuzamate.global.success.GeneralSuccessCode;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,6 +24,9 @@ public class StockController {
 
     private final StockCodeService stockCodeService;
     private final NasdaqService nasdaqService;
+    private final KrxService krxService;
+    private final KrxInquireService krxInquireService;
+    private final KrxFinancialService krxFinancialService;
 
     @PostMapping("/post-stock-codes")
     @Operation(summary = "주식 코드 저장", description = "코스피, 코스닥, 나스닥 주식 코드를 저장합니다.")
@@ -53,5 +56,31 @@ public class StockController {
 
         nasdaqService.saveNasdaqStocksInfo();
         return CustomResponse.onSuccess(GeneralSuccessCode.CREATED, "나스닥 주식 전체 정보 저장 완료");
+    }
+
+    @PostMapping("/krx/all")
+    @Operation(summary = "KRX(코스피, 코스닥)의 정보 가져오고 저장",
+    description =  "주식 현재가, per, pbr, 종목코드, 업종, 영업 이익 증가율, EPS, ROE 값을 가져오고 저장합니다")
+    public CustomResponse<?> getAllKrxStockInfo() {
+
+        krxService.saveKrxStocksInfo();
+        return CustomResponse.onSuccess(GeneralSuccessCode.CREATED, "KRX 주식 전체 정보 저장 완료");
+
+    }
+
+    @PostMapping("/inquire/{krxStockCode}")
+    @Operation(summary = "수동으로 KRX 주식 한 개의 inquire 정보 가져오기",
+            description = "KRX 주식 한 개의 inquire 정보를 가져옵니다. 주식 코드를 입력해야 합니다.")
+    public KrxDto.InquireDto getKrxStockInfoDto(@PathVariable("krxStockCode") String krxStockCode) {
+
+        return krxInquireService.getCurInquireInfo(krxStockCode);
+    }
+
+    @PostMapping("/financial/{krxStockCode}")
+    @Operation(summary = "수동으로 KRX 주식 한 개의 financial 정보 가져오기",
+            description = "KRX 주식 한 개의 financial 정보를 가져옵니다. 주식 코드를 입력해야 합니다.")
+    public KrxDto.FinancialDto getKrxFinancialInfoDto(@PathVariable("krxStockCode") String krxStockCode) {
+
+        return krxFinancialService.getCurFinancialInfo(krxStockCode);
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/stock/dto/krx/KrxDto.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/dto/krx/KrxDto.java
@@ -1,0 +1,67 @@
+package naughty.tuzamate.domain.stock.dto.krx;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import naughty.tuzamate.domain.stock.entity.KrxStockInfo;
+
+public class KrxDto {
+
+
+    @Getter
+    @Setter
+    public static class InquireDto {
+
+        @JsonProperty("stck_prpr")
+        private String stckPrpr;     // 주식 현재가
+
+        private String per;           // PER
+
+        private String pbr;           // PBR
+
+        @JsonProperty("stck_shrn_iscd")
+        private String stckShrnIscd; // 주식 단축 종목코드
+
+        @JsonProperty("bstp_kor_isnm")
+        private String bstpKorIsnm; // 업종 한글 종목명
+    }
+
+    @Getter
+    @Setter
+    public static class FinancialDto {
+
+        @JsonProperty("bsop_prfi_inrt")
+        private String bsopPrfiInrt; // 영업 이익 증가율
+
+        private String eps; // EPS
+
+        @JsonProperty("roe_val")
+        private String roeVal; // ROE 값
+    }
+
+    @Getter
+    public static class KrxStockInfoDto {
+        private String stck_prpr;     // 주식 현재가
+        private String per;     // PER
+        private String pbr;     // PBR
+        private String stck_shrn_iscd;     // 주식 단축 종목코드
+        private String bstp_kor_isnm; // 업종 한글 종목명
+        private String bsop_prfi_inrt; // 영업 이익 증가율
+        private String roe_val; // ROE 값
+        private String eps; // EPS
+
+        public KrxStockInfo toEntity(KrxDto.InquireDto inquireDto,
+                                     KrxDto.FinancialDto financialDto) {
+            return KrxStockInfo.builder()
+                    .stckShrnIscd(inquireDto.getStckShrnIscd())
+                    .per(inquireDto.getPer())
+                    .pbr(inquireDto.getPbr())
+                    .stckPrpr(inquireDto.getStckPrpr())
+                    .bstpKorIsnm(inquireDto.getBstpKorIsnm())
+                    .bsopPrfiInrt(financialDto.getBsopPrfiInrt())
+                    .roeVal(financialDto.getRoeVal())
+                    .eps(financialDto.getEps())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/dto/nasdaq/NasdaqDto.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/dto/nasdaq/NasdaqDto.java
@@ -1,6 +1,5 @@
-package naughty.tuzamate.domain.stock.dto;
+package naughty.tuzamate.domain.stock.dto.nasdaq;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import naughty.tuzamate.domain.stock.entity.NasdaqStockInfo;

--- a/src/main/java/naughty/tuzamate/domain/stock/entity/KrxStockInfo.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/entity/KrxStockInfo.java
@@ -1,0 +1,35 @@
+package naughty.tuzamate.domain.stock.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class KrxStockInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String stckShrnIscd; // 주식 단축 종목코드
+
+    private String per;
+
+    private String pbr;
+
+    private String stckPrpr; // 주식 현재가
+
+    private String bstpKorIsnm; // 업종 한글 종목명
+
+    private String bsopPrfiInrt; // 영업 이익 증가율
+
+    private String roeVal; // ROE 값
+
+    private String eps; // 주당 순이익 (Earnings Per Share)
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/repository/KrxStockInfoRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/repository/KrxStockInfoRepository.java
@@ -1,0 +1,7 @@
+package naughty.tuzamate.domain.stock.repository;
+
+import naughty.tuzamate.domain.stock.entity.KrxStockInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KrxStockInfoRepository  extends JpaRepository<KrxStockInfo, Long> {
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/service/KrxFinancialService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/KrxFinancialService.java
@@ -1,0 +1,108 @@
+package naughty.tuzamate.domain.stock.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import naughty.tuzamate.auth.hantu.service.HantuApiTokenService;
+import naughty.tuzamate.domain.stock.dto.krx.KrxDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * 한국투자증권에서 주식현재가 시세 API를 통해 주식 영업 이익 증가율, EPS, ROE 값을
+ * 조회하는 서비스입니다.
+ */
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class KrxFinancialService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final HantuApiTokenService hantuApiTokenService;
+
+    @Value("${tuza.api.APP_KEY}")
+    private String appKey;
+
+    @Value("${tuza.api.APP_SECRET_KEY}")
+    private String appSecret;
+
+    private String accessToken;
+
+    public KrxDto.FinancialDto getCurFinancialInfo(String stockCode) {
+
+        HttpHeaders httpHeaders = createHeaders();
+
+        String url = "https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/finance/financial-ratio";
+
+        HttpEntity<?> httpEntity = new HttpEntity<>(httpHeaders);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url)
+                .queryParam("FID_DIV_CLS_CODE", "1")
+                .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                .queryParam("FID_INPUT_ISCD", stockCode);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                builder.toUriString(),
+                HttpMethod.GET,
+                httpEntity,
+                String.class
+        );
+
+
+        return parsingCurrentFinanceInfo(response.getBody());
+    }
+
+    private KrxDto.FinancialDto parsingCurrentFinanceInfo(String response) {
+
+        KrxDto.FinancialDto data = new KrxDto.FinancialDto();
+
+        try {
+            JsonNode jsonNode = objectMapper.readTree(response);
+            JsonNode arrayNode = jsonNode.path("output");
+            /**
+             * 한투의 재무비율 관련 API 응답을 보면  output: List[ResponseBodyoutput] 형태
+             * output은 ResponseBody가 아닌 배열
+             * 한 번더 열어야 한다.
+             */
+
+            JsonNode node = arrayNode.get(0);
+            if (node != null) {
+                KrxDto.FinancialDto outputDto = new KrxDto.FinancialDto();
+
+                outputDto.setBsopPrfiInrt(node.path("bsop_prfi_inrt").asText());
+                outputDto.setEps(node.path("eps").asText());
+                outputDto.setRoeVal(node.path("roe_val").asText());
+
+                data = outputDto;
+            }
+
+            return data;
+
+        } catch (Exception e) {
+            log.error("FinanceService Error is : {}", e.getMessage());
+            throw new RuntimeException();
+        }
+    }
+
+    private HttpHeaders createHeaders() {
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        accessToken = hantuApiTokenService.getCurrentAccessToken();
+        httpHeaders.setBearerAuth(accessToken);
+        httpHeaders.set("appkey", appKey);
+        httpHeaders.set("appsecret", appSecret);
+        httpHeaders.set("tr_id", "FHKST66430300");
+        httpHeaders.set("custtype", "P");
+
+        return httpHeaders;
+    }
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/service/KrxInquireService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/KrxInquireService.java
@@ -1,0 +1,103 @@
+package naughty.tuzamate.domain.stock.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.hantu.service.HantuApiTokenService;
+import naughty.tuzamate.domain.stock.dto.krx.KrxDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.http.*;
+
+
+/**
+ * 한국투자증권에서 주식현재가 시세 API를 통해 주식 현재가, PER, PBR, 주식 단축 종목코드, 업종 한글 종목명을
+ * 조회하는 서비스입니다.
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class KrxInquireService {
+
+    private final RestTemplate restTemplate;
+    private final HantuApiTokenService hantuApiTokenService;
+    private final ObjectMapper objectMapper;
+
+
+    @Value("${tuza.api.APP_KEY}")
+    private String appKey;
+
+    @Value("${tuza.api.APP_SECRET_KEY}")
+    private String appSecret;
+
+    private String accessToken;
+
+    public KrxDto.InquireDto getCurInquireInfo(String stockCode) {
+
+        HttpHeaders headers = createHeaders();
+        String url = "https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/quotations/inquire-price";
+
+        HttpEntity<?> httpEntity = new HttpEntity<>(headers);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url)
+                .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                .queryParam("FID_INPUT_ISCD", stockCode);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                builder.toUriString(),
+                HttpMethod.GET,
+                httpEntity,
+                String.class
+        );
+
+        return parsingCurInquireInfo(response.getBody());
+    }
+
+    private KrxDto.InquireDto parsingCurInquireInfo(String response) {
+
+        KrxDto.InquireDto data = new KrxDto.InquireDto();
+
+        try {
+            JsonNode rootNode = objectMapper.readTree(response);
+            JsonNode node = rootNode.path("output");
+
+            if (node != null) {
+                KrxDto.InquireDto outputDto = new KrxDto.InquireDto();
+
+                outputDto.setStckPrpr(node.path("stck_prpr").asText());
+                outputDto.setPer(node.path("per").asText());
+                outputDto.setPbr(node.path("pbr").asText());
+                outputDto.setStckShrnIscd(node.path("stck_shrn_iscd").asText());
+                outputDto.setBstpKorIsnm(node.path("bstp_kor_isnm").asText());
+                data = outputDto;
+            }
+            return data;
+        } catch (Exception e) {
+            throw new RuntimeException("Error parsing response: " + e.getMessage(), e);
+        }
+    }
+
+    private HttpHeaders createHeaders() {
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        accessToken = hantuApiTokenService.getCurrentAccessToken();
+        httpHeaders.setBearerAuth(accessToken);
+        httpHeaders.set("appkey", appKey);
+        httpHeaders.set("appsecret", appSecret);
+        httpHeaders.set("tr_id", "FHKST01010100");
+        httpHeaders.set("custtype", "P");
+
+        return httpHeaders;
+
+
+    }
+
+
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/service/KrxService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/KrxService.java
@@ -1,0 +1,67 @@
+package naughty.tuzamate.domain.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import naughty.tuzamate.domain.stock.dto.krx.KrxDto;
+import naughty.tuzamate.domain.stock.entity.KrxStockInfo;
+import naughty.tuzamate.domain.stock.entity.StockCode;
+import naughty.tuzamate.domain.stock.repository.KrxStockInfoRepository;
+import naughty.tuzamate.domain.stock.repository.code.StockCodeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class KrxService {
+
+    private final StockCodeRepository stockCodeRepository;
+    private final KrxInquireService krxInquireService;
+    private final KrxFinancialService krxFinancialService;
+    private final KrxStockInfoRepository krxStockInfoRepository;
+
+    public void saveKrxStocksInfo() {
+
+        List<StockCode> stockCodeList = stockCodeRepository.findAll();
+
+        krxStockInfoRepository.deleteAllInBatch();
+
+        for (StockCode stockCode : stockCodeList) {
+            try {
+
+                Thread.sleep(100);
+
+                // 주식 코드를 이용해 현재가, PER, PBR, 업종 한글 종목명 조회
+                KrxDto.InquireDto currentPerPbrOutputDto = krxInquireService.getCurInquireInfo(stockCode.getCode());
+                // 주식 코드를 이용해 영업 이익 증가율, EPS, ROE 값 조회
+                KrxDto.FinancialDto currentFinanceOutputDto = krxFinancialService.getCurFinancialInfo(stockCode.getCode()); 
+
+                log.info("PER: {}", currentPerPbrOutputDto.getPer());
+                log.info("EPS: {}", currentFinanceOutputDto.getEps());
+
+
+
+                KrxDto.KrxStockInfoDto stockInfoDto = new KrxDto.KrxStockInfoDto();
+
+                KrxStockInfo stockInfo = stockInfoDto.toEntity(
+                        currentPerPbrOutputDto,
+                        currentFinanceOutputDto
+                );
+
+                krxStockInfoRepository.save(stockInfo);
+
+                log.info("Saved stocks is : {}", stockCode.getCode());
+
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt(); // 현재 스레드 인터럽트 상태 복구
+                log.info("Thread Interrupted : {}", e.getMessage());
+                break;
+            } catch (Exception e) {
+                log.info("Error stock code is {} : {} and pass!", stockCode.getCode(), e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/service/NasdaqService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/NasdaqService.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import naughty.tuzamate.auth.hantu.service.HantuApiTokenService;
-import naughty.tuzamate.domain.stock.dto.NasdaqDto;
+import naughty.tuzamate.domain.stock.dto.nasdaq.NasdaqDto;
 import naughty.tuzamate.domain.stock.entity.NasdaqStockCode;
 import naughty.tuzamate.domain.stock.entity.NasdaqStockInfo;
 import naughty.tuzamate.domain.stock.repository.NasdaqStockInfoRepository;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #31 

## 📌 개요
- 한투 API를 이용해 한국 주식 정보를 저장한다.

## 🔁 변경 사항
4c5076ab4d598aee46b08a09631ceab604ca05cc
## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Korea Exchange (KRX) stock data, including endpoints to retrieve and store KRX stock information, inquiry details, and financial metrics.
  * Introduced new data models and services for handling KRX stock inquiry and financial data.
  * Users can now access KRX stock information alongside existing Nasdaq data.

* **Bug Fixes**
  * None.

* **Refactor**
  * Updated package structure for Nasdaq-related data transfer objects to improve organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->