### PR TITLE
[FEAT] 주식 종목 이름 가져오는 API 코드 구현

### DIFF
--- a/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import naughty.tuzamate.domain.stock.dto.StockInfoDto;
 import naughty.tuzamate.domain.stock.dto.krx.KrxDto;
 import naughty.tuzamate.domain.stock.dto.nasdaq.NasdaqDto;
 import naughty.tuzamate.domain.stock.error.StockErrorCode;
@@ -27,6 +28,7 @@ public class StockController {
     private final KrxService krxService;
     private final KrxInquireService krxInquireService;
     private final KrxFinancialService krxFinancialService;
+    private final StockInfoService stockInfoService;
 
     @PostMapping("/post-stock-codes")
     @Operation(summary = "주식 코드 저장", description = "코스피, 코스닥, 나스닥 주식 코드를 저장합니다.")
@@ -60,7 +62,7 @@ public class StockController {
 
     @PostMapping("/krx/all")
     @Operation(summary = "KRX(코스피, 코스닥)의 정보 가져오고 저장",
-    description =  "주식 현재가, per, pbr, 종목코드, 업종, 영업 이익 증가율, EPS, ROE 값을 가져오고 저장합니다")
+            description = "주식 현재가, per, pbr, 종목코드, 업종, 영업 이익 증가율, EPS, ROE 값, 상품 이름을 가져오고 저장합니다")
     public CustomResponse<?> getAllKrxStockInfo() {
 
         krxService.saveKrxStocksInfo();
@@ -82,5 +84,15 @@ public class StockController {
     public KrxDto.FinancialDto getKrxFinancialInfoDto(@PathVariable("krxStockCode") String krxStockCode) {
 
         return krxFinancialService.getCurFinancialInfo(krxStockCode);
+    }
+
+    @PostMapping("/stock-info/{stockCode}/{marketCode}")
+    @Operation(summary = "수동으로 주식 한 개의 기본 정보 가져오기. 주식 이름만 가져오게 됩니다.",
+            description = "주식 한 개의 기본 정보를 가져옵니다. 주식 코드와 시장 코드를 입력해야 합니다." +
+                    " 한국 시장 코드는 '300'으로 입력하면 KRX, '512'으로 입력하면 NASDAQ입니다.")
+    public StockInfoDto.InfoDto getKrxStockInfo(@PathVariable("stockCode") String stockCode,
+                                                @PathVariable("marketCode") String marketCode) {
+
+        return stockInfoService.getStockInfo(stockCode, marketCode);
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/stock/dto/StockInfoDto.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/dto/StockInfoDto.java
@@ -1,0 +1,17 @@
+package naughty.tuzamate.domain.stock.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+public class StockInfoDto {
+
+    @Getter
+    @Setter
+    public static class InfoDto {
+
+        @JsonProperty("prdt_abrv_name")
+        private String prdtAbrvName; // 상품 약어명
+    }
+
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/dto/krx/KrxDto.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/dto/krx/KrxDto.java
@@ -3,6 +3,7 @@ package naughty.tuzamate.domain.stock.dto.krx;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
+import naughty.tuzamate.domain.stock.dto.StockInfoDto;
 import naughty.tuzamate.domain.stock.entity.KrxStockInfo;
 
 public class KrxDto {
@@ -39,6 +40,7 @@ public class KrxDto {
         private String roeVal; // ROE 값
     }
 
+
     @Getter
     public static class KrxStockInfoDto {
         private String stck_prpr;     // 주식 현재가
@@ -49,9 +51,11 @@ public class KrxDto {
         private String bsop_prfi_inrt; // 영업 이익 증가율
         private String roe_val; // ROE 값
         private String eps; // EPS
+        private String prdt_abrv_name; // 상품 약어명
 
         public KrxStockInfo toEntity(KrxDto.InquireDto inquireDto,
-                                     KrxDto.FinancialDto financialDto) {
+                                     KrxDto.FinancialDto financialDto,
+                                     StockInfoDto.InfoDto stockInfoDto) {
             return KrxStockInfo.builder()
                     .stckShrnIscd(inquireDto.getStckShrnIscd())
                     .per(inquireDto.getPer())
@@ -61,6 +65,7 @@ public class KrxDto {
                     .bsopPrfiInrt(financialDto.getBsopPrfiInrt())
                     .roeVal(financialDto.getRoeVal())
                     .eps(financialDto.getEps())
+                    .prdtAbrvName(stockInfoDto.getPrdtAbrvName())
                     .build();
         }
     }

--- a/src/main/java/naughty/tuzamate/domain/stock/dto/nasdaq/NasdaqDto.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/dto/nasdaq/NasdaqDto.java
@@ -2,6 +2,7 @@ package naughty.tuzamate.domain.stock.dto.nasdaq;
 
 import lombok.Getter;
 import lombok.Setter;
+import naughty.tuzamate.domain.stock.dto.StockInfoDto;
 import naughty.tuzamate.domain.stock.entity.NasdaqStockInfo;
 
 public class NasdaqDto {
@@ -16,14 +17,16 @@ public class NasdaqDto {
     private String epsx; // EPS
     private String e_icod; // 업종 섹터
 
-    public NasdaqStockInfo toEntity( NasdaqDto.NasdaqInfoDto dto) {
+    public NasdaqStockInfo toEntity(NasdaqDto.NasdaqInfoDto nasdaqInfoDto, StockInfoDto.InfoDto stockInfoDto) {
       return NasdaqStockInfo.builder()
-              .code(dto.code)
-              .perx(dto.perx)
-              .pbrx(dto.pbrx)
-              .epsx(dto.epsx)
-              .eIcod(dto.e_icod)
+              .code(nasdaqInfoDto.code)
+              .perx(nasdaqInfoDto.perx)
+              .pbrx(nasdaqInfoDto.pbrx)
+              .epsx(nasdaqInfoDto.epsx)
+              .eIcod(nasdaqInfoDto.e_icod)
+              .prdtAbrvName(stockInfoDto.getPrdtAbrvName())
               .build();
     }
+
   }
 }

--- a/src/main/java/naughty/tuzamate/domain/stock/entity/KrxStockInfo.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/entity/KrxStockInfo.java
@@ -32,4 +32,6 @@ public class KrxStockInfo {
     private String roeVal; // ROE 값
 
     private String eps; // 주당 순이익 (Earnings Per Share)
+
+    private String prdtAbrvName; // 상품 약어명
 }

--- a/src/main/java/naughty/tuzamate/domain/stock/entity/NasdaqStockInfo.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/entity/NasdaqStockInfo.java
@@ -22,4 +22,6 @@ public class NasdaqStockInfo {
     private String pbrx; // PBR
     private String epsx; // EPS
     private String eIcod; // 업종 섹터
+
+    private String prdtAbrvName; // 상품 약어명
 }

--- a/src/main/java/naughty/tuzamate/domain/stock/service/KrxService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/KrxService.java
@@ -2,6 +2,7 @@ package naughty.tuzamate.domain.stock.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import naughty.tuzamate.domain.stock.dto.StockInfoDto;
 import naughty.tuzamate.domain.stock.dto.krx.KrxDto;
 import naughty.tuzamate.domain.stock.entity.KrxStockInfo;
 import naughty.tuzamate.domain.stock.entity.StockCode;
@@ -13,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 @Slf4j
 public class KrxService {
@@ -22,6 +22,7 @@ public class KrxService {
     private final KrxInquireService krxInquireService;
     private final KrxFinancialService krxFinancialService;
     private final KrxStockInfoRepository krxStockInfoRepository;
+    private final StockInfoService stockInfoService;
 
     public void saveKrxStocksInfo() {
 
@@ -37,18 +38,19 @@ public class KrxService {
                 // 주식 코드를 이용해 현재가, PER, PBR, 업종 한글 종목명 조회
                 KrxDto.InquireDto currentPerPbrOutputDto = krxInquireService.getCurInquireInfo(stockCode.getCode());
                 // 주식 코드를 이용해 영업 이익 증가율, EPS, ROE 값 조회
-                KrxDto.FinancialDto currentFinanceOutputDto = krxFinancialService.getCurFinancialInfo(stockCode.getCode()); 
+                KrxDto.FinancialDto currentFinanceOutputDto = krxFinancialService.getCurFinancialInfo(stockCode.getCode());
+                StockInfoDto.InfoDto currentKrxStockInfoDto = stockInfoService.getStockInfo(stockCode.getCode(), "300");
 
-                log.info("PER: {}", currentPerPbrOutputDto.getPer());
+               /* log.info("PER: {}", currentPerPbrOutputDto.getPer());
                 log.info("EPS: {}", currentFinanceOutputDto.getEps());
-
-
+                log.info("NAME: {}", currentKrxStockInfoDto.getPrdtAbrvName());*/
 
                 KrxDto.KrxStockInfoDto stockInfoDto = new KrxDto.KrxStockInfoDto();
 
                 KrxStockInfo stockInfo = stockInfoDto.toEntity(
                         currentPerPbrOutputDto,
-                        currentFinanceOutputDto
+                        currentFinanceOutputDto,
+                        currentKrxStockInfoDto
                 );
 
                 krxStockInfoRepository.save(stockInfo);

--- a/src/main/java/naughty/tuzamate/domain/stock/service/NasdaqService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/NasdaqService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import naughty.tuzamate.auth.hantu.service.HantuApiTokenService;
+import naughty.tuzamate.domain.stock.dto.StockInfoDto;
 import naughty.tuzamate.domain.stock.dto.nasdaq.NasdaqDto;
 import naughty.tuzamate.domain.stock.entity.NasdaqStockCode;
 import naughty.tuzamate.domain.stock.entity.NasdaqStockInfo;
@@ -28,6 +29,7 @@ public class NasdaqService {
     private final NasdaqCodeRepository nasdaqCodeRepository;
     private final NasdaqStockInfoRepository nasdaqStockInfoRepository;
     private final HantuApiTokenService hantuApiTokenService;
+    private final StockInfoService stockInfoService;
 
     @Value("${tuza.api.APP_KEY}")
     private String appKey;
@@ -113,11 +115,12 @@ public class NasdaqService {
                 Thread.sleep(100);
 
                 NasdaqDto.NasdaqInfoDto currentNasdaqInfo = getCurrentNasdaqInfo(stockCode.getCode());
+                StockInfoDto.InfoDto currentStockInfo = stockInfoService.getStockInfo(stockCode.getCode(), "512");
 
                /* log.info("PER: {}", currentNasdaqInfo.getPerx());
                 log.info("EPS: {}", currentNasdaqInfo.getEpsx());*/
 
-                NasdaqStockInfo entity = currentNasdaqInfo.toEntity(currentNasdaqInfo);
+                NasdaqStockInfo entity = currentNasdaqInfo.toEntity(currentNasdaqInfo, currentStockInfo);
 
                 nasdaqStockInfoRepository.save(entity);
 

--- a/src/main/java/naughty/tuzamate/domain/stock/service/StockInfoService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/StockInfoService.java
@@ -1,0 +1,96 @@
+package naughty.tuzamate.domain.stock.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.hantu.service.HantuApiTokenService;
+import naughty.tuzamate.domain.stock.dto.StockInfoDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * 주식 상품 기본 조회
+ * 한투의 "상품 기본 조회" API를 통해 주식의 상품 이름(주식 이름)을 얻어온다.
+ */
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StockInfoService {
+
+
+    private final RestTemplate restTemplate;
+    private final HantuApiTokenService hantuApiTokenService;
+    private final ObjectMapper objectMapper;
+
+    @Value("${tuza.api.APP_KEY}")
+    private String appKey;
+
+    @Value("${tuza.api.APP_SECRET_KEY}")
+    private String appSecret;
+
+    private String accessToken;
+
+    // 주식의 상품이름을 얻어오는 메소드
+    // marketCode 300 : 한국 주식, 512 : 미국 주식
+    public StockInfoDto.InfoDto getStockInfo(String stockCode, String marketCode) {
+
+        HttpHeaders headers = createHeaders();
+        String url = "https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/quotations/search-info";
+
+        HttpEntity<?> httpEntity = new HttpEntity<>(headers);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url)
+                .queryParam("PDNO", stockCode)
+                .queryParam("PRDT_TYPE_CD", marketCode);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                builder.toUriString(),
+                HttpMethod.GET,
+                httpEntity,
+                String.class
+        );
+
+        return parsingKrxInfo(response.getBody());
+
+    }
+
+    private StockInfoDto.InfoDto parsingKrxInfo(String response) {
+
+        StockInfoDto.InfoDto data = new StockInfoDto.InfoDto();
+
+        try {
+            JsonNode rootNode = objectMapper.readTree(response);
+            JsonNode node = rootNode.path("output");
+
+            if (node != null) {
+                StockInfoDto.InfoDto outputDto = new StockInfoDto.InfoDto();
+
+                outputDto.setPrdtAbrvName(node.path("prdt_abrv_name").asText());
+                data = outputDto;
+            }
+            return data;
+        } catch (Exception e) {
+            throw new RuntimeException("Error parsing response: " + e.getMessage(), e);
+        }
+    }
+
+    private HttpHeaders createHeaders() {
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        accessToken = hantuApiTokenService.getCurrentAccessToken();
+        httpHeaders.setBearerAuth(accessToken);
+        httpHeaders.set("appkey", appKey);
+        httpHeaders.set("appsecret", appSecret);
+        httpHeaders.set("tr_id", "CTPF1604R");
+        httpHeaders.set("custtype", "P");
+
+        return httpHeaders;
+
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #34 

## 📌 개요
- 한투의 search-info 관련 API를 이용해 주식 종목 이름을 가져온다.

## 🔁 변경 사항
9d379f9b3461fe0d8ed49b15545cec88c89983d5
## 📸 스크린샷
![image](https://github.com/user-attachments/assets/5cf72425-b9a1-4c1b-89dd-4474ab735c44)
## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to fetch basic stock information (stock name) by stock code and market code.
  * Introduced support for retrieving and storing product abbreviation names for both KRX and NASDAQ stocks.
* **Enhancements**
  * Stock information now includes product abbreviation names for improved detail in KRX and NASDAQ stock data.
* **Documentation**
  * Updated endpoint descriptions to reflect the inclusion of product names in fetched and stored data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->