### PR TITLE
[Feat] 한국투자증권 한국 주식 응답값 Roe 필드값 삭제

### DIFF
--- a/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
@@ -62,7 +62,7 @@ public class StockController {
 
     @PostMapping("/krx/all")
     @Operation(summary = "KRX(코스피, 코스닥)의 정보 가져오고 저장",
-            description = "주식 현재가, per, pbr, 종목코드, 업종, EPS, ROE 값, 상품 이름을 가져오고 저장합니다")
+            description = "주식 현재가, per, pbr, 종목코드, 업종, EPS, 상품 이름을 가져오고 저장합니다")
     public CustomResponse<?> getAllKrxStockInfo() {
 
         krxService.saveKrxStocksInfo();

--- a/src/main/java/naughty/tuzamate/domain/stock/dto/krx/KrxDto.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/dto/krx/KrxDto.java
@@ -33,8 +33,6 @@ public class KrxDto {
 
         private String eps; // EPS
 
-        @JsonProperty("roe_val")
-        private String roeVal; // ROE 값
     }
 
 
@@ -45,7 +43,6 @@ public class KrxDto {
         private String pbr;     // PBR
         private String stck_shrn_iscd;     // 주식 단축 종목코드
         private String bstp_kor_isnm; // 업종 한글 종목명
-        private String roe_val; // ROE 값
         private String eps; // EPS
         private String prdt_abrv_name; // 상품 약어명
 
@@ -58,7 +55,6 @@ public class KrxDto {
                     .pbr(inquireDto.getPbr())
                     .stckPrpr(inquireDto.getStckPrpr())
                     .bstpKorIsnm(inquireDto.getBstpKorIsnm())
-                    .roeVal(financialDto.getRoeVal())
                     .eps(financialDto.getEps())
                     .prdtAbrvName(stockInfoDto.getPrdtAbrvName())
                     .build();

--- a/src/main/java/naughty/tuzamate/domain/stock/entity/KrxStockInfo.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/entity/KrxStockInfo.java
@@ -27,8 +27,6 @@ public class KrxStockInfo {
 
     private String bstpKorIsnm; // 업종 한글 종목명
 
-    private String roeVal; // ROE 값
-
     private String eps; // 주당 순이익 (Earnings Per Share)
 
     private String prdtAbrvName; // 상품 약어명

--- a/src/main/java/naughty/tuzamate/domain/stock/service/KrxFinancialService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/KrxFinancialService.java
@@ -14,7 +14,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
- * 한국투자증권에서 주식현재가 시세 API를 통해 주식 EPS, ROE 값을
+ * 한국투자증권에서 주식현재가 시세 API를 통해 주식 EPS 값을
  * 조회하는 서비스입니다.
  */
 
@@ -78,7 +78,6 @@ public class KrxFinancialService {
                 KrxDto.FinancialDto outputDto = new KrxDto.FinancialDto();
 
                 outputDto.setEps(node.path("eps").asText("0.00"));
-                outputDto.setRoeVal(node.path("roe_val").asText());
 
                 data = outputDto;
             }

--- a/src/main/java/naughty/tuzamate/domain/stock/service/KrxService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/KrxService.java
@@ -38,7 +38,7 @@ public class KrxService {
 
                 // 주식 코드를 이용해 현재가, PER, PBR, 업종 한글 종목명 조회
                 KrxDto.InquireDto currentPerPbrOutputDto = krxInquireService.getCurInquireInfo(stockCode.getCode());
-                // 주식 코드를 이용해 영업 이익 증가율, EPS, ROE 값 조회
+                // 주식 코드를 이용해 EPS 값 조회
                 KrxDto.FinancialDto currentFinanceOutputDto = krxFinancialService.getCurFinancialInfo(stockCode.getCode());
                 StockInfoDto.InfoDto currentKrxStockInfoDto = stockInfoService.getStockInfo(stockCode.getCode(), "300");
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #38 

## 📌 개요
- dto에서 roe 값 삭제
- service에서 roe 값 삭제
- roe 필드 값 삭제

## 🔁 변경 사항

## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation and internal comments to remove references to the ROE value for KRX stock information.

* **Refactor**
  * Removed all ROE-related fields from stock data structures and entities.
  * Adjusted data processing logic to exclude ROE value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->