### PR TITLE
[Feat] 로그인 API 관련 로그아웃, 리플레쉬 토큰 재발급 로직 추가

### DIFF
--- a/src/main/java/naughty/tuzamate/auth/controller/AuthController.java
+++ b/src/main/java/naughty/tuzamate/auth/controller/AuthController.java
@@ -1,14 +1,22 @@
 package naughty.tuzamate.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.dto.TokenResponse;
+import naughty.tuzamate.auth.jwt.JwtProvider;
 import naughty.tuzamate.auth.service.AuthService;
 import naughty.tuzamate.auth.success.AuthSuccessCode;
 import naughty.tuzamate.global.apiPayload.CustomResponse;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtProvider jwtProvider;
 
     @GetMapping("/auth/logout")
     @Operation(summary = "로그아웃", description = "로그아웃을 수행합니다.")
@@ -25,5 +34,30 @@ public class AuthController {
         String bearer = request.getHeader(HttpHeaders.AUTHORIZATION);
         authService.logout(bearer);
         return CustomResponse.onSuccess(AuthSuccessCode.LOGOUT_SUCCESS_CODE);
+    }
+
+    @PostMapping("/auth/refresh")
+    @Operation(summary = "토큰 재발급", description = "만료된 액세스 토큰을 재발급받습니다.")
+    public CustomResponse<?> reissueToken(
+            @Parameter(
+                    name = "refreshToken",
+                    description = "리프레시 토큰을 쿠키에 넣어 요청",
+                    in = ParameterIn.COOKIE,
+                    required = true
+            )
+            @CookieValue("refreshToken") String refreshToken, HttpServletResponse response
+    ) {
+        TokenResponse.TokenDto tokenDto = authService.reissueToken(refreshToken);
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", tokenDto.getRefreshToken())
+                .httpOnly(true)
+                .secure(true) // 테스트 시 false
+                .path("/")
+                .sameSite("Lax")
+                .maxAge(jwtProvider.getRefreshExpiration())
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        return CustomResponse.onSuccess(AuthSuccessCode.ACCESS_TOKEN_REISSUE_SUCCESS_CODE);
     }
 }

--- a/src/main/java/naughty/tuzamate/auth/controller/AuthController.java
+++ b/src/main/java/naughty/tuzamate/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package naughty.tuzamate.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.service.AuthService;
+import naughty.tuzamate.auth.success.AuthSuccessCode;
+import naughty.tuzamate.global.apiPayload.CustomResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "인증", description = "인증 관련 API")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/auth/logout")
+    @Operation(summary = "로그아웃", description = "로그아웃을 수행합니다.")
+    public CustomResponse<?> logout(HttpServletRequest request) {
+
+        String bearer = request.getHeader(HttpHeaders.AUTHORIZATION);
+        authService.logout(bearer);
+        return CustomResponse.onSuccess(AuthSuccessCode.LOGOUT_SUCCESS_CODE);
+    }
+}

--- a/src/main/java/naughty/tuzamate/auth/dto/TokenResponse.java
+++ b/src/main/java/naughty/tuzamate/auth/dto/TokenResponse.java
@@ -1,0 +1,19 @@
+package naughty.tuzamate.auth.dto;
+
+import lombok.Getter;
+
+public class TokenResponse {
+
+    @Getter
+    public static class TokenDto {
+
+        private final String accessToken;
+        private final String refreshToken;
+
+        public TokenDto(String newAccessToken, String newRefreshToken) {
+            this.accessToken = newAccessToken;
+            this.refreshToken = newRefreshToken;
+        }
+    }
+
+}

--- a/src/main/java/naughty/tuzamate/auth/entity/RefreshToken.java
+++ b/src/main/java/naughty/tuzamate/auth/entity/RefreshToken.java
@@ -13,14 +13,10 @@ import java.time.LocalDateTime;
 public class RefreshToken {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long userId;
 
     @Column(nullable = false, unique = true)
     private String token;
-
-    @Column(nullable = false)
-    private Long userId;
 
     @Column(nullable = false)
     private LocalDateTime expireDate;

--- a/src/main/java/naughty/tuzamate/auth/entity/RefreshToken.java
+++ b/src/main/java/naughty/tuzamate/auth/entity/RefreshToken.java
@@ -27,4 +27,8 @@ public class RefreshToken {
         this.expireDate = expireDate;
     }
 
+    public void update(String token) {
+        this.token = token;
+    }
+
 }

--- a/src/main/java/naughty/tuzamate/auth/jwt/JwtFilter.java
+++ b/src/main/java/naughty/tuzamate/auth/jwt/JwtFilter.java
@@ -7,12 +7,17 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import naughty.tuzamate.auth.jwt.error.JwtErrorCode;
+import naughty.tuzamate.auth.principal.PrincipalDetails;
 import naughty.tuzamate.auth.principal.PrincipalDetailsService;
+import naughty.tuzamate.domain.user.entity.User;
+import naughty.tuzamate.domain.user.repository.UserRepository;
 import naughty.tuzamate.global.apiPayload.CustomResponse;
 import naughty.tuzamate.global.error.BaseErrorCode;
 import naughty.tuzamate.global.error.exception.CustomException;
 import naughty.tuzamate.domain.user.error.UserErrorCode;
 import naughty.tuzamate.domain.user.error.exception.UserCustomException;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -27,6 +32,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final PrincipalDetailsService principalDetailsService;
+    private final UserRepository userRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -35,15 +41,31 @@ public class JwtFilter extends OncePerRequestFilter {
             String header = request.getHeader("Authorization");
             if (header != null && header.startsWith("Bearer ")) {
                 String token = header.split(" ")[1];
-                String email = jwtProvider.getEmail(token);
-                UserDetails userDetails = principalDetailsService.loadUserByUsername(email);
 
-                if (userDetails != null) {
+                jwtProvider.isValid(token);
+
+                Long userId = jwtProvider.getUserId(token);
+                int tokenVersion = jwtProvider.getTokenVersion(token);
+                User user = userRepository.findById(userId).orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
+                if(user.getTokenVersion() != tokenVersion) {
+                    throw new CustomException(UserErrorCode.LOGGED_OUT_USER);
+                }
+
+                /*String email = jwtProvider.getEmail(token);
+                UserDetails userDetails = principalDetailsService.loadUserByUsername(email);
+                */
+
+                UserDetails userDetails = new PrincipalDetails(user);
+
+                /*if (userDetails != null) {
                     Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 } else {
                     throw new UserCustomException(UserErrorCode.USER_NOT_FOUND);
-                }
+                }*/
+
+                Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
             }
 
             filterChain.doFilter(request, response);

--- a/src/main/java/naughty/tuzamate/auth/jwt/JwtFilter.java
+++ b/src/main/java/naughty/tuzamate/auth/jwt/JwtFilter.java
@@ -37,6 +37,12 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
+        if (request.getRequestURI().equals("/auth/refresh")) {
+            log.info("CookieHeader : {}", request.getHeader("Cookie"));
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         try {
             String header = request.getHeader("Authorization");
             if (header != null && header.startsWith("Bearer ")) {

--- a/src/main/java/naughty/tuzamate/auth/jwt/JwtProvider.java
+++ b/src/main/java/naughty/tuzamate/auth/jwt/JwtProvider.java
@@ -123,6 +123,7 @@ public class JwtProvider {
                 .setHeader(Map.of("alg", "HS256", "typ", "JWT")) // JWT header 설정
                 .setSubject(member.getEmail()) // JWT의 Subject을 email로 설정
                 .claim("id", member.getId()) // id 를 Claim으로 추가
+                .claim("tokenVersion", member.getTokenVersion()) // tokenVersion을 Claim으로 추가
                 .setIssuedAt(Date.from(issuedAt)) // 만들어진 시간을 현재 시간으로 설정
                 .setExpiration(Date.from(expiredAt)) // 유효기간 설정
                 .signWith(secret, SignatureAlgorithm.HS256) // 암호화를 위한 sign 설정
@@ -155,6 +156,14 @@ public class JwtProvider {
             // INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN401", "토큰이 유효하지 않습니다."),
 
         }
+    }
+
+    public Long getUserId(String token) {
+        return getClaims(token).getBody().get("id", Long.class);
+    }
+
+    public int getTokenVersion(String token) {
+        return getClaims(token).getBody().get("tokenVersion", Integer.class);
     }
 
     public String getEmail(String token) {

--- a/src/main/java/naughty/tuzamate/auth/service/AuthService.java
+++ b/src/main/java/naughty/tuzamate/auth/service/AuthService.java
@@ -1,0 +1,45 @@
+package naughty.tuzamate.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.jwt.JwtProvider;
+import naughty.tuzamate.auth.jwt.error.JwtErrorCode;
+import naughty.tuzamate.auth.repository.RefreshTokenRepository;
+import naughty.tuzamate.domain.user.entity.User;
+import naughty.tuzamate.domain.user.error.UserErrorCode;
+import naughty.tuzamate.domain.user.error.exception.UserCustomException;
+import naughty.tuzamate.domain.user.repository.UserRepository;
+import naughty.tuzamate.global.error.exception.CustomException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    /**
+     * user의 tokenVersion을 1 증가시킨다. -> 기존 토큰을 무효화 시킨다
+     * DB에 저장된 refreshToken을 삭제한다.
+     */
+    public void logout(String bearer) {
+
+        if (bearer == null || !bearer.startsWith("Bearer ")) {
+            throw new CustomException(JwtErrorCode.JWT_BAD_REQUEST_400); //잘못된 형식의 토큰입니다.
+        }
+
+        String token = bearer.substring(7);
+
+        jwtProvider.isValid(token);
+
+        Long userId = jwtProvider.getUserId(token);
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
+        user.increaseTokenVersion();
+
+        refreshTokenRepository.deleteById(userId);
+    }
+}

--- a/src/main/java/naughty/tuzamate/auth/service/AuthService.java
+++ b/src/main/java/naughty/tuzamate/auth/service/AuthService.java
@@ -1,6 +1,8 @@
 package naughty.tuzamate.auth.service;
 
 import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.dto.TokenResponse;
+import naughty.tuzamate.auth.entity.RefreshToken;
 import naughty.tuzamate.auth.jwt.JwtProvider;
 import naughty.tuzamate.auth.jwt.error.JwtErrorCode;
 import naughty.tuzamate.auth.repository.RefreshTokenRepository;
@@ -41,5 +43,34 @@ public class AuthService {
         user.increaseTokenVersion();
 
         refreshTokenRepository.deleteById(userId);
+    }
+
+    public TokenResponse.TokenDto reissueToken(String token) {
+
+        jwtProvider.isValid(token); // 토큰 유효성 검사
+
+        Long userId = jwtProvider.getUserId(token);
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
+
+        if (user.getTokenVersion() != jwtProvider.getTokenVersion(token)) {
+            throw new CustomException(UserErrorCode.LOGGED_OUT_USER); // 의도적으로 토큰을 더 이상 신뢰하지 않는지 확인
+        }
+
+        RefreshToken storedToken = refreshTokenRepository.findById(userId).orElseThrow(
+                () -> new CustomException(JwtErrorCode.TOKEN_INVALID));
+
+        // 기존 리플레쉬 토큰을 재사용하지 못하도록 한다. (if문의 다음 코드를 사용하지 못하게)
+        if (!storedToken.getToken().equals(token)) { // 폐기된 토큰을 재사용 -> 탈취된 것
+            refreshTokenRepository.deleteById(userId);
+            throw new CustomException(JwtErrorCode.TOKEN_INVALID); // 저장된 토큰과 일치하지 않으면 예외 발생
+        }
+
+        String newAccessToken = jwtProvider.createAccessToken(user);
+        String newRefreshToken = jwtProvider.createRefreshToken(user);
+
+        storedToken.update(newRefreshToken);
+
+        return new TokenResponse.TokenDto(newAccessToken, newRefreshToken);
+
     }
 }

--- a/src/main/java/naughty/tuzamate/auth/success/AuthSuccessCode.java
+++ b/src/main/java/naughty/tuzamate/auth/success/AuthSuccessCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum AuthSuccessCode implements BaseSuccessCode {
 
     AUTH_SUCCESS_CODE(HttpStatus.ACCEPTED, "AUTH200", "인가 코드 발급이 성공했습니다."),
-    LOGOUT_SUCCESS_CODE(HttpStatus.OK, "AUTH200", "로그아웃이 되었습니다.")
+    LOGOUT_SUCCESS_CODE(HttpStatus.OK, "AUTH200", "로그아웃이 되었습니다."),
+
+    ACCESS_TOKEN_REISSUE_SUCCESS_CODE(HttpStatus.OK, "AUTH202", "액세스 토큰 재발급이 성공했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/naughty/tuzamate/auth/success/AuthSuccessCode.java
+++ b/src/main/java/naughty/tuzamate/auth/success/AuthSuccessCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AuthSuccessCode implements BaseSuccessCode {
 
     AUTH_SUCCESS_CODE(HttpStatus.ACCEPTED, "AUTH200", "인가 코드 발급이 성공했습니다."),
+    LOGOUT_SUCCESS_CODE(HttpStatus.OK, "AUTH200", "로그아웃이 되었습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/naughty/tuzamate/domain/user/entity/User.java
+++ b/src/main/java/naughty/tuzamate/domain/user/entity/User.java
@@ -59,6 +59,19 @@ public class User extends BaseTimeEntity {
 
     private SocialType socialType;
 
+
+    /**
+     * 회원의 마지막 로그아웃 이후 발급되는 토큰을 판별하기 위한 사용
+     * 처음엔 0, 이후 로그아웃 시 + 1
+     */
+    @Column(nullable = false)
+    private int tokenVersion = 0;
+
+    public void increaseTokenVersion() {
+        this.tokenVersion++;
+    }
+
+
    /* @Column(nullable = false)
     private String accessToken;
 
@@ -71,6 +84,7 @@ public class User extends BaseTimeEntity {
     }*/
 
     public void updateNickname(String nickname) {
+
         this.nickname = nickname;
     }
 

--- a/src/main/java/naughty/tuzamate/domain/user/error/UserErrorCode.java
+++ b/src/main/java/naughty/tuzamate/domain/user/error/UserErrorCode.java
@@ -15,7 +15,8 @@ public enum UserErrorCode implements BaseErrorCode {
     OAUTH_TOKEN_FAIL(HttpStatus.UNAUTHORIZED, "USER40101", "인가코드로 토큰을 가져오는데 실패했습니다."),
     OAUTH_USER_INFO_FAIL(HttpStatus.UNAUTHORIZED, "USER40102", "토큰으로 사용자 정보를 가져오는 데 실패했습니다."),
     UNSUPPORTED_OAUTH_TYPE(HttpStatus.BAD_REQUEST, "USER400", "지원하지 않는 소셜 로그인입니다."),
-    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "USER401", "인증되지 않은 사용자입니다.")
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "USER401", "인증되지 않은 사용자입니다."),
+    LOGGED_OUT_USER(HttpStatus.UNAUTHORIZED, "USER40101", "로그아웃된 사용자입니다. 다시 로그인 해주세요.")
     ;
 
 

--- a/src/main/java/naughty/tuzamate/global/config/SecurityConfig.java
+++ b/src/main/java/naughty/tuzamate/global/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import naughty.tuzamate.auth.jwt.JwtProvider;
 import naughty.tuzamate.auth.jwt.error.handler.JwtAccessDeniedHandler;
 import naughty.tuzamate.auth.jwt.error.handler.JwtAuthenticationEntryPoint;
 import naughty.tuzamate.auth.principal.PrincipalDetailsService;
+import naughty.tuzamate.domain.user.repository.UserRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -29,6 +30,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final PrincipalDetailsService principalDetailsService;
     private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
 
     private final String[] allowUrls = {
             "/",
@@ -48,7 +50,7 @@ public class SecurityConfig {
 
     @Bean
     public Filter jwtFilter() {
-        return new JwtFilter(jwtProvider, principalDetailsService);
+        return new JwtFilter(jwtProvider, principalDetailsService, userRepository);
     }
 
     @Bean

--- a/src/main/java/naughty/tuzamate/global/config/SecurityConfig.java
+++ b/src/main/java/naughty/tuzamate/global/config/SecurityConfig.java
@@ -39,7 +39,8 @@ public class SecurityConfig {
             "/swagger-ui.html",
             "/auth/kakao-oauth",
             "/signUp",
-            "/login"
+            "/login",
+            "/auth/refresh"
     };
 
     @Bean


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #33 

## 📌 개요
- 로그아웃 API은 version을 만들어 관리를 수행 081862531d34c0e5181577f47e8ade80a800a1c1
- 리플레쉬 토큰 재발급 API는 쿠키를 사용해 재발급을 수행 7801908fca0e69ee90f5391fd70c0433980c7de2

## 🔁 변경 사항
- 리플레쉬 토큰 재발급 API는 SecurityConfig에서 permitAll() 하게 됨
- 리플레쉬 토큰의 엔티티의 PK를 유저의 ID로 고정시킴

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/cbc90f3f-3dff-419a-ba0e-fb0e013bf731)

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)
- 리플레쉬 재발급 관련 API에 대한 반환값 확인 스웨거가 아닌 Postman으로 수행하는 것을 권장
- 물론 스웨거에서 개발자 도구를 통해 토큰값을 넣어 할 수 있음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication endpoints for logout and token refresh, allowing users to securely log out and reissue access tokens.
  * Introduced secure handling of refresh tokens via HTTP-only cookies.
  * Enhanced token validation and user authentication with improved security checks.
  * Added clear success and error messages for authentication-related actions.

* **Improvements**
  * Strengthened token lifecycle management, ensuring tokens are invalidated on logout and preventing reuse of old tokens.
  * Expanded public API documentation for authentication endpoints.

* **Bug Fixes**
  * Addressed potential issues with token reuse and unauthorized access after logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->