### PR TITLE
[REFACTOR] : 유저 필드 값 변경 및 삭제

### DIFF
--- a/src/main/java/naughty/tuzamate/domain/profile/converter/ProfileConverter.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/converter/ProfileConverter.java
@@ -19,15 +19,15 @@ public class ProfileConverter {
                 .experience(user.isExperience())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
-                .funding_situation(user.getFunding_situation())
+                .funding_situation(user.getFundingSituation())
                 .income(user.getIncome())
                 .stability(user.getStability())
                 .source(user.getSource())
                 .type(user.getType())
                 .proportion(user.getProportion())
                 .period(user.getPeriod())
-                .expected_income(user.getExpected_income())
-                .expected_loss(user.getExpected_loss())
+                .expected_income(user.getExpectedIncome())
+                .expected_loss(user.getExpectedLoss())
                 .purpose(user.getPurpose())
                 .build();
     }

--- a/src/main/java/naughty/tuzamate/domain/user/entity/User.java
+++ b/src/main/java/naughty/tuzamate/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package naughty.tuzamate.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import naughty.tuzamate.domain.user.enums.Gender;
 import naughty.tuzamate.global.BaseTimeEntity;
 import naughty.tuzamate.domain.user.enums.SocialType;
 
@@ -20,7 +21,7 @@ public class User extends BaseTimeEntity {
 
     private String password;
   
-    private Long gender;
+    private Gender gender;
 
     private Long age;
 
@@ -31,7 +32,7 @@ public class User extends BaseTimeEntity {
 
     private String nickname;
 
-    private String funding_situation;
+    private String fundingSituation;
 
     private Long income;
 
@@ -47,28 +48,24 @@ public class User extends BaseTimeEntity {
     @Column(name = "investment_proportion")
     private String proportion;
 
-    private Long period;
+    private Long period; // 예상 투자 기간
 
-    private Long expected_income;
+    private Long expectedIncome;
 
-    private Long expected_loss;
+    private Long expectedLoss;
 
-    private String purpose;
+    @Column(name = "ivestment_purpose")
+    private String purpose; // 투자 목적
 
     private String role;
 
     private SocialType socialType;
 
-   /* @Column(nullable = false)
-    private String accessToken;
+    private Long credit; // 크레딧
 
-    @Column(nullable = false)
-    private String refreshToken;
+    @Column(columnDefinition = "TEXT")
+    private String recentRecommendedProduct; // 최근 추천 상품
 
-    public void updateTokens(String accessToken, String refreshToken) {
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-    }*/
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;

--- a/src/main/java/naughty/tuzamate/domain/user/enums/Gender.java
+++ b/src/main/java/naughty/tuzamate/domain/user/enums/Gender.java
@@ -1,5 +1,5 @@
 package naughty.tuzamate.domain.user.enums;
 
-public enum SocialType {
-    KAKAO;
+public enum Gender {
+    MALE, FEMALE
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #41 

## 📌 개요
- 소셜 타입 삭제
- 크레딧, 최근 추천 상품 필드 값 추가
- 성별 enum으로 변경

## 🔁 변경 사항
- 성별(Gender) enum 값으로 변경
- recentRecommendedProduct(최근 추천 상품) 필드 값을 ai 쪽에서 json 형태로 넣는 것으로 생각
## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)
- recentRecommendedProduct 필드 값을 JSON 형태로 입력되게 하는 게 어떤지
Ex)
```json
{
  "type": "annuity", // 혹은 "deposit", "savings"
  "id": 12345,
  "name": "OOO 연금 상품" // 유저에게 보여줄 때 사용
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added new fields to user profiles for credit and most recent recommended product.
  * Introduced gender selection with options for male and female.

* **Improvements**
  * Enhanced naming consistency for user profile fields.
  * Improved type safety for the gender field.

* **Removals**
  * Removed support for NAVER and GOOGLE as social login options, leaving only KAKAO.
  * Removed previously unused token-related fields from user profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->