### PR TITLE
feat : BoardType ENUM 속성 POST에 추가, refactor : postController,Service,Repository,Converter 코드를 커서 페이지네이션 기반으로 수정

### DIFF
--- a/src/main/java/naughty/tuzamate/auth/principal/PrincipalDetails.java
+++ b/src/main/java/naughty/tuzamate/auth/principal/PrincipalDetails.java
@@ -24,6 +24,10 @@ public class PrincipalDetails implements UserDetails {
         return roles.stream().map(SimpleGrantedAuthority::new).toList();
     }
 
+    public Long getId() {
+        return user.getId();
+    }
+
     @Override
     public String getUsername() {
         return user.getEmail();

--- a/src/main/java/naughty/tuzamate/domain/post/controller/PostController.java
+++ b/src/main/java/naughty/tuzamate/domain/post/controller/PostController.java
@@ -1,48 +1,63 @@
 package naughty.tuzamate.domain.post.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
 import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.principal.PrincipalDetails;
 import naughty.tuzamate.domain.post.dto.PostReqDTO;
 import naughty.tuzamate.domain.post.dto.PostResDTO;
 import naughty.tuzamate.domain.post.entity.Post;
+import naughty.tuzamate.domain.post.enums.BoardType;
 import naughty.tuzamate.domain.post.service.command.PostCommandService;
 import naughty.tuzamate.domain.post.service.query.PostQueryService;
 import naughty.tuzamate.global.apiPayload.CustomResponse;
 import naughty.tuzamate.global.success.GeneralSuccessCode;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/posts")
+
+@Tag(name = "게시판 컨트롤러", description = "게시판 관련 API")
 public class PostController {
 
     private final PostCommandService postCommandService;
     private final PostQueryService postQueryService;
 
-    @PostMapping("")
+    @PostMapping("/boards/{boardType}/posts")
+    @Operation(summary = "게시글 생성", description = "게시판에 맞는 게시글을 생성합니다.")
     public CustomResponse<PostResDTO.CreatePostResponseDTO> createPost(
-            @RequestBody PostReqDTO.CreatePostRequestDTO reqDTO) {
-        PostResDTO.CreatePostResponseDTO resDTO = postCommandService.createPost(reqDTO);
+            @PathVariable BoardType boardType,
+            @RequestBody PostReqDTO.CreatePostRequestDTO reqDTO,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        PostResDTO.CreatePostResponseDTO resDTO = postCommandService.createPost(boardType, reqDTO, principalDetails);
 
         return CustomResponse.onSuccess(GeneralSuccessCode.CREATED, resDTO);
     }
 
-    @GetMapping("/{postId}")
+    @GetMapping("/boards/{boardType}/posts/{postId}")
+    @Operation(summary = "단일 게시글 조회", description = "단일 게시글을 조회합니다.")
     public CustomResponse<PostResDTO.PostPreviewDTO> getPost(@PathVariable Long postId) {
         PostResDTO.PostPreviewDTO resDTO = postQueryService.getPost(postId);
 
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, resDTO);
     }
 
-    @GetMapping("")
-    public CustomResponse<PostResDTO.PostPreviewListDTO> getPostList() {
-        PostResDTO.PostPreviewListDTO resDTO = postQueryService.getPostList();
+    @GetMapping("/boards/{boardType}/posts")
+    @Operation(summary = "게시글 목록 조회", description = "각 BoardType(FREE, INFO)에 맞는 게시글 목록을 조회합니다.")
+    public CustomResponse<PostResDTO.PostPreviewListDTO> getPostList(
+            @PathVariable BoardType boardType,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "10") @Max(30) int size) {
+        PostResDTO.PostPreviewListDTO resDTO = postQueryService.getPostList(boardType, cursor, size);
 
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, resDTO);
     }
 
-    @PatchMapping("/{postId}")
+    @PatchMapping("/boards/{boardType}/posts/{postId}")
+    @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
     public CustomResponse<PostResDTO.UpdatePostResponseDTO> updatePost(
             @PathVariable Long postId,
             @RequestBody PostReqDTO.UpdatePostRequestDTO reqDTO) {
@@ -51,51 +66,53 @@ public class PostController {
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, resDTO);
     }
 
-    @DeleteMapping("/{postId}")
+    @DeleteMapping("/boards/{boardType}/posts/{postId}")
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
     public CustomResponse<PostResDTO.DeletePostResponseDTO> deletePost(@PathVariable Long postId) {
         PostResDTO.DeletePostResponseDTO resDTO = postCommandService.deletePost(postId);
 
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, resDTO);
     }
 
-    // PostLike
-    @PostMapping("/{postId}/likes")
+    @PostMapping("posts/{postId}/likes")
+    @Operation(summary = "게시글 좋아요 증가", description = "게시글에 좋아요를 눌러 PostLike에 PostId를 저장하고, Post의 likeNum을 증가시킵니다.")
     public CustomResponse<String> increaseLike(
-            @PathVariable Long postId,
-            @RequestParam Long userId
+            @PathVariable Long postId, @AuthenticationPrincipal PrincipalDetails principalDetails
     ) {
-        String message = postCommandService.postLike(postId, userId);
+        String message = postCommandService.postLike(postId, principalDetails);
 
         return CustomResponse.onSuccess(GeneralSuccessCode.CREATED, message);
     }
 
-    @DeleteMapping("/{postId}/likes")
+    @DeleteMapping("posts/{postId}/likes")
+    @Operation(summary = "게시글 좋아요 감소", description = "게시글에 좋아요를 다시 눌러 PostLike를 삭제하고, Post의 likeNum을 감소시킵니다.")
     public CustomResponse<String> deleteLike(
             @PathVariable Long postId,
-            @RequestParam Long userId
+            @AuthenticationPrincipal PrincipalDetails principalDetails
     ) {
-        String message = postCommandService.deleteLike(postId, userId);
+        String message = postCommandService.deleteLike(postId, principalDetails);
 
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, message);
     }
 
-    // PostScrap
-    @PostMapping("/{postId}/scraps")
+    @PostMapping("posts/{postId}/scraps")
+    @Operation(summary = "게시글 스크랩 기능", description = "스크랩 기능을 이용해 PostScrap에 저장합니다.")
     public CustomResponse<String> postScrap(
             @PathVariable Long postId,
-            @RequestParam Long userId
+            @AuthenticationPrincipal PrincipalDetails principalDetails
     ) {
-        String message = postCommandService.postScrap(postId, userId);
+        String message = postCommandService.postScrap(postId, principalDetails);
 
         return CustomResponse.onSuccess(GeneralSuccessCode.CREATED, message);
     }
 
-    @DeleteMapping("/{postId}/scraps")
+    @DeleteMapping("posts/{postId}/scraps")
+    @Operation(summary = "게시글 스크랩 취소 기능", description = "스크랩 기능을 재이용해 PostScrap을 삭제합니다.")
     public CustomResponse<String> deleteScrap(
             @PathVariable Long postId,
-            @RequestParam Long userId
+            @AuthenticationPrincipal PrincipalDetails principalDetails
     ) {
-        String message = postCommandService.deleteScrap(postId, userId);
+        String message = postCommandService.deleteScrap(postId, principalDetails);
 
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, message);
     }

--- a/src/main/java/naughty/tuzamate/domain/post/converter/PostConverter.java
+++ b/src/main/java/naughty/tuzamate/domain/post/converter/PostConverter.java
@@ -5,6 +5,8 @@ import lombok.NoArgsConstructor;
 import naughty.tuzamate.domain.post.dto.PostReqDTO;
 import naughty.tuzamate.domain.post.dto.PostResDTO;
 import naughty.tuzamate.domain.post.entity.Post;
+import naughty.tuzamate.domain.post.enums.BoardType;
+import naughty.tuzamate.domain.user.entity.User;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -13,11 +15,13 @@ import java.util.stream.Collectors;
 public class PostConverter {
 
     // CreatePostRequestDTO -> Post Entity
-    public static Post toPost(PostReqDTO.CreatePostRequestDTO reqDTO) {
+    public static Post toPost(BoardType boardType, PostReqDTO.CreatePostRequestDTO reqDTO, User user) {
         return Post.builder()
                 .title(reqDTO.title())
                 .content(reqDTO.content())
                 .likeNum(0L)
+                .boardType(boardType)
+                .user(user)
                 .build();
     }
 
@@ -36,21 +40,23 @@ public class PostConverter {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .likeNum(post.getLikeNum())
+                .author(post.getUser().getNickname())
+                .commentNum((long) post.getComments().size()) // 댓글 수
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
     }
 
     // Post Entities -> PostPreviewListDTO
-    public static PostResDTO.PostPreviewListDTO toPostPreviewListDTO(List<Post> posts) {
-        List<PostResDTO.PostPreviewDTO> previewDTOList = posts.stream()
-                .map(PostConverter::toPostPreviewDTO)
-                .collect(Collectors.toList());
-
-        return PostResDTO.PostPreviewListDTO.builder()
-                .postPreviewDTOList(previewDTOList)
-                .build();
-    }
+//    public static PostResDTO.PostPreviewListDTO toPostPreviewListDTO(List<Post> posts) {
+//        List<PostResDTO.PostPreviewDTO> previewDTOList = posts.stream()
+//                .map(PostConverter::toPostPreviewDTO)
+//                .collect(Collectors.toList());
+//
+//        return PostResDTO.PostPreviewListDTO.builder()
+//                .postPreviewDTOList(previewDTOList)
+//                .build();
+//    }
 
     // Post Entity -> UpdatePostResponseDTO
     public static PostResDTO.UpdatePostResponseDTO toUpdatePostResponseDTO(Post post) {

--- a/src/main/java/naughty/tuzamate/domain/post/dto/PostReqDTO.java
+++ b/src/main/java/naughty/tuzamate/domain/post/dto/PostReqDTO.java
@@ -1,5 +1,7 @@
 package naughty.tuzamate.domain.post.dto;
 
+import naughty.tuzamate.domain.post.enums.BoardType;
+
 public class PostReqDTO {
 
     public record CreatePostRequestDTO(

--- a/src/main/java/naughty/tuzamate/domain/post/dto/PostResDTO.java
+++ b/src/main/java/naughty/tuzamate/domain/post/dto/PostResDTO.java
@@ -20,6 +20,9 @@ public class PostResDTO {
             String title,
             String content,
             Long likeNum,
+            // 작성자 닉네임, 댓글 수 필드 추가
+            String author,
+            Long commentNum,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ){
@@ -27,7 +30,9 @@ public class PostResDTO {
 
     @Builder
     public record PostPreviewListDTO(
-            List<PostPreviewDTO> postPreviewDTOList
+            List<PostPreviewDTO> postPreviewDTOList,
+            Long nextCursor,
+            boolean hasNext
     ){
     }
 

--- a/src/main/java/naughty/tuzamate/domain/post/entity/Post.java
+++ b/src/main/java/naughty/tuzamate/domain/post/entity/Post.java
@@ -3,6 +3,7 @@ package naughty.tuzamate.domain.post.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import naughty.tuzamate.domain.comment.entity.Comment;
+import naughty.tuzamate.domain.post.enums.BoardType;
 import naughty.tuzamate.domain.postLike.entity.PostLike;
 import naughty.tuzamate.global.BaseTimeEntity;
 import naughty.tuzamate.domain.user.entity.User;
@@ -28,6 +29,9 @@ public class Post extends BaseTimeEntity {
 
     @Column(name = "like_num")
     private Long likeNum;
+
+    @Enumerated(EnumType.STRING)
+    private BoardType boardType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/naughty/tuzamate/domain/post/enums/BoardType.java
+++ b/src/main/java/naughty/tuzamate/domain/post/enums/BoardType.java
@@ -1,0 +1,5 @@
+package naughty.tuzamate.domain.post.enums;
+
+public enum BoardType {
+    FREE, INFO
+}

--- a/src/main/java/naughty/tuzamate/domain/post/repository/PostRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/post/repository/PostRepository.java
@@ -1,7 +1,18 @@
 package naughty.tuzamate.domain.post.repository;
 
 import naughty.tuzamate.domain.post.entity.Post;
+import naughty.tuzamate.domain.post.enums.BoardType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+    @Query(value = """
+    SELECT p FROM Post p
+    WHERE p.boardType = :boardType
+      AND (:cursor IS NULL OR p.id < :cursor)
+    ORDER BY p.id DESC
+    """)
+    Slice<Post> findByBoardTypeAndCursor(BoardType boardType, Long cursor, Pageable pageable);
 }

--- a/src/main/java/naughty/tuzamate/domain/post/service/command/PostCommandService.java
+++ b/src/main/java/naughty/tuzamate/domain/post/service/command/PostCommandService.java
@@ -1,16 +1,18 @@
 package naughty.tuzamate.domain.post.service.command;
 
+import naughty.tuzamate.auth.principal.PrincipalDetails;
 import naughty.tuzamate.domain.post.dto.PostReqDTO;
 import naughty.tuzamate.domain.post.dto.PostResDTO;
 import naughty.tuzamate.domain.post.entity.Post;
+import naughty.tuzamate.domain.post.enums.BoardType;
 
 public interface PostCommandService {
 
-    PostResDTO.CreatePostResponseDTO createPost(PostReqDTO.CreatePostRequestDTO reqDTO);
+    PostResDTO.CreatePostResponseDTO createPost(BoardType boardType, PostReqDTO.CreatePostRequestDTO reqDTO, PrincipalDetails principalDetails);
     PostResDTO.UpdatePostResponseDTO updatePost(PostReqDTO.UpdatePostRequestDTO reqDTO, Long postId);
     PostResDTO.DeletePostResponseDTO deletePost(Long postId);
-    String postLike(Long postId, Long userId);
-    String deleteLike(Long postId, Long userId);
-    String postScrap(Long postId, Long userId);
-    String deleteScrap(Long postId, Long userId);
+    String postLike(Long postId, PrincipalDetails principalDetails);
+    String deleteLike(Long postId, PrincipalDetails principalDetails);
+    String postScrap(Long postId, PrincipalDetails principalDetails);
+    String deleteScrap(Long postId, PrincipalDetails principalDetails);
 }

--- a/src/main/java/naughty/tuzamate/domain/post/service/command/PostCommandServiceImpl.java
+++ b/src/main/java/naughty/tuzamate/domain/post/service/command/PostCommandServiceImpl.java
@@ -1,10 +1,12 @@
 package naughty.tuzamate.domain.post.service.command;
 
 import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.principal.PrincipalDetails;
 import naughty.tuzamate.domain.post.converter.PostConverter;
 import naughty.tuzamate.domain.post.dto.PostReqDTO;
 import naughty.tuzamate.domain.post.dto.PostResDTO;
 import naughty.tuzamate.domain.post.entity.Post;
+import naughty.tuzamate.domain.post.enums.BoardType;
 import naughty.tuzamate.domain.post.repository.PostRepository;
 import naughty.tuzamate.domain.postLike.entity.PostLike;
 import naughty.tuzamate.domain.postLike.repository.PostLikeRepository;
@@ -28,9 +30,11 @@ public class PostCommandServiceImpl implements PostCommandService {
     private final PostScrapRepository postScrapRepository;
 
     @Override
-    public PostResDTO.CreatePostResponseDTO createPost(PostReqDTO.CreatePostRequestDTO reqDTO) {
+    public PostResDTO.CreatePostResponseDTO createPost(BoardType boardType, PostReqDTO.CreatePostRequestDTO reqDTO, PrincipalDetails principalDetails) {
         // reqDTO -> Post Entity 로 변환, Post Entity -> resDTO 로 return
-        Post post = PostConverter.toPost(reqDTO);
+        User user = userRepository.getReferenceById(principalDetails.getId());
+        Post post = PostConverter.toPost(boardType, reqDTO, user);
+
         postRepository.save(post);
 
         return PostConverter.toCreatePostResponseDTO(post);
@@ -63,17 +67,21 @@ public class PostCommandServiceImpl implements PostCommandService {
     }
 
     @Override
-    public String postLike(Long postId, Long userId) {
+    public String postLike(Long postId, PrincipalDetails principalDetails) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(GeneralErrorCode.NOT_FOUND_404));
-        User user = userRepository.findById(userId)
+        User user = userRepository.findById(principalDetails.getId())
                 .orElseThrow(() -> new CustomException(GeneralErrorCode.NOT_FOUND_404));
 
         if (postLikeRepository.existsByPostAndUser(post, user)) {
             throw new CustomException(GeneralErrorCode.ALREADY_LIKED);
         }
 
-        PostLike like = PostLike.builder().post(post).user(user).build();
+        PostLike like = PostLike.builder()
+                .post(post)
+                .user(user)
+                .build();
+
         postLikeRepository.save(like);
 
         post.increaseLike();
@@ -82,10 +90,10 @@ public class PostCommandServiceImpl implements PostCommandService {
     }
 
     @Override
-    public String deleteLike(Long postId, Long userId) {
+    public String deleteLike(Long postId, PrincipalDetails principalDetails) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(GeneralErrorCode.NOT_FOUND_404));
-        User user = userRepository.findById(userId)
+        User user = userRepository.findById(principalDetails.getId())
                 .orElseThrow(() -> new CustomException(GeneralErrorCode.NOT_FOUND_404));
 
         PostLike like = postLikeRepository.findByPostAndUser(post, user);
@@ -97,10 +105,10 @@ public class PostCommandServiceImpl implements PostCommandService {
     }
 
     @Override
-    public String postScrap(Long postId, Long userId) {
+    public String postScrap(Long postId, PrincipalDetails principalDetails) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(GeneralErrorCode.NOT_FOUND_404));
-        User user = userRepository.findById(userId)
+        User user = userRepository.findById(principalDetails.getId())
                 .orElseThrow(() -> new CustomException(GeneralErrorCode.NOT_FOUND_404));
 
         if (postScrapRepository.existsByPostAndUser(post, user)) {
@@ -114,10 +122,10 @@ public class PostCommandServiceImpl implements PostCommandService {
     }
 
     @Override
-    public String deleteScrap(Long postId, Long userId) {
+    public String deleteScrap(Long postId, PrincipalDetails principalDetails) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(GeneralErrorCode.NOT_FOUND_404));
-        User user = userRepository.findById(userId)
+        User user = userRepository.findById(principalDetails.getId())
                 .orElseThrow(() -> new CustomException(GeneralErrorCode.NOT_FOUND_404));
 
         PostScrap scrap = postScrapRepository.findByPostAndUser(post, user);

--- a/src/main/java/naughty/tuzamate/domain/post/service/query/PostQueryService.java
+++ b/src/main/java/naughty/tuzamate/domain/post/service/query/PostQueryService.java
@@ -1,10 +1,10 @@
 package naughty.tuzamate.domain.post.service.query;
 
-import naughty.tuzamate.domain.post.dto.PostReqDTO;
 import naughty.tuzamate.domain.post.dto.PostResDTO;
+import naughty.tuzamate.domain.post.enums.BoardType;
 
 public interface PostQueryService {
 
     PostResDTO.PostPreviewDTO getPost(Long postId);
-    PostResDTO.PostPreviewListDTO getPostList();
+    PostResDTO.PostPreviewListDTO getPostList(BoardType boardType, Long cursor, int size);
 }

--- a/src/main/java/naughty/tuzamate/domain/post/service/query/PostQueryServiceImpl.java
+++ b/src/main/java/naughty/tuzamate/domain/post/service/query/PostQueryServiceImpl.java
@@ -4,11 +4,16 @@ import lombok.RequiredArgsConstructor;
 import naughty.tuzamate.domain.post.converter.PostConverter;
 import naughty.tuzamate.domain.post.dto.PostResDTO;
 import naughty.tuzamate.domain.post.entity.Post;
+import naughty.tuzamate.domain.post.enums.BoardType;
 import naughty.tuzamate.domain.post.repository.PostRepository;
 import naughty.tuzamate.global.error.GeneralErrorCode;
 import naughty.tuzamate.global.error.exception.CustomException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -17,8 +22,6 @@ public class PostQueryServiceImpl implements PostQueryService {
 
     private final PostRepository postRepository;
 
-
-    // Post error 코드 및 exception만들기!!!!!!
     @Override
     public PostResDTO.PostPreviewDTO getPost(Long postId) {
         Post post = postRepository.findById(postId)
@@ -28,7 +31,21 @@ public class PostQueryServiceImpl implements PostQueryService {
     }
 
     @Override
-    public PostResDTO.PostPreviewListDTO getPostList() {
-        return PostConverter.toPostPreviewListDTO(postRepository.findAll());
+    public PostResDTO.PostPreviewListDTO getPostList(BoardType boardType, Long cursor, int size) {
+        PageRequest pr = PageRequest.of(0, size);
+        Slice<Post> slice = postRepository.findByBoardTypeAndCursor(boardType, cursor, pr);
+
+        List<PostResDTO.PostPreviewDTO> previews = slice.getContent()
+                .stream()
+                .map(PostConverter::toPostPreviewDTO)
+                .toList();
+
+        Long nextCursor = slice.hasNext() ? previews.get(previews.size() - 1).id() : null;
+
+        return PostResDTO.PostPreviewListDTO.builder()
+                .postPreviewDTOList(previews)
+                .nextCursor(nextCursor)
+                .hasNext(slice.hasNext())
+                .build();
     }
 }


### PR DESCRIPTION
refactor : PostController, PostService, PostRepository, PostConverter 커서 페이지네이션에 맞게 코드 리팩토링

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #44 

## 📌 개요
- Post 관련 속성 추가 및 페이지네이션 구현

## 🔁 변경 사항
- Post 속성에 들어갈 BoardType ENUM 추가
- 커서 기반 페이지네이션에 맞는 PostController, PostService, PostRepository, PostConverter로 코드 변경

## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [x] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced board categories (FREE, INFO) for posts, allowing users to interact with posts by board type.
  * Added cursor-based pagination to post listings, including indicators for next page availability.
  * Post previews now display the author's nickname and comment count.

* **Improvements**
  * API endpoints for posts are now organized by board type for clearer navigation.
  * Enhanced API documentation for post-related endpoints.
  * User actions such as liking and scrapping posts now rely on authentication, removing the need for user ID in requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->