### PR TITLE
Feat: 커뮤니티 확인 기능 추가

### DIFF
--- a/src/main/java/naughty/tuzamate/domain/community/CommunityItem.java
+++ b/src/main/java/naughty/tuzamate/domain/community/CommunityItem.java
@@ -1,0 +1,9 @@
+package naughty.tuzamate.domain.community;
+
+import naughty.tuzamate.domain.post.entity.Post;
+
+public interface CommunityItem {
+
+    Long getCursorId(); // cursor
+    Post getPost(); // 게시글 정보 - 제목, 내용 요약
+}

--- a/src/main/java/naughty/tuzamate/domain/post/entity/Post.java
+++ b/src/main/java/naughty/tuzamate/domain/post/entity/Post.java
@@ -3,6 +3,7 @@ package naughty.tuzamate.domain.post.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import naughty.tuzamate.domain.comment.entity.Comment;
+import naughty.tuzamate.domain.community.CommunityItem;
 import naughty.tuzamate.domain.postLike.entity.PostLike;
 import naughty.tuzamate.global.BaseTimeEntity;
 import naughty.tuzamate.domain.user.entity.User;
@@ -16,7 +17,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class Post extends BaseTimeEntity {
+public class Post extends BaseTimeEntity implements CommunityItem {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -55,5 +56,14 @@ public class Post extends BaseTimeEntity {
     public void addComment(Comment comment) {
         comments.add(comment);
         comment.setPost(this);
+    }
+
+    @Override
+    public Long getCursorId() {
+        return this.id;
+    }
+    @Override
+    public Post getPost() {
+        return this;
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/post/repository/PostRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/post/repository/PostRepository.java
@@ -1,7 +1,18 @@
 package naughty.tuzamate.domain.post.repository;
 
 import naughty.tuzamate.domain.post.entity.Post;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    // 커서가 없는 경우 유저가 작성한 글 최신순 조회
+    @Query("select p from Post p where p.user.id = :userId and p.deletedAt is null order by p.id desc")
+    Slice<Post> findPostListByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+
+    // 커서가 있을 때 해당 커서 이전 유저가 작성한 글 최신순 조회
+    @Query("select p from Post p where p.user.id = :userId and p.deletedAt is null and p.id < :cursorId order by p.id desc")
+    Slice<Post> findPostListByUserIdLessThanOrderByIdDesc(Long userId, Long cursorId, Pageable pageable);
 }

--- a/src/main/java/naughty/tuzamate/domain/post/repository/PostRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/post/repository/PostRepository.java
@@ -5,14 +5,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 커서가 없는 경우 유저가 작성한 글 최신순 조회
     @Query("select p from Post p where p.user.id = :userId and p.deletedAt is null order by p.id desc")
-    Slice<Post> findPostListByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+    Slice<Post> findPostListByUserIdOrderByIdDesc(@Param("userId") Long userId, Pageable pageable);
 
     // 커서가 있을 때 해당 커서 이전 유저가 작성한 글 최신순 조회
     @Query("select p from Post p where p.user.id = :userId and p.deletedAt is null and p.id < :cursorId order by p.id desc")
-    Slice<Post> findPostListByUserIdLessThanOrderByIdDesc(Long userId, Long cursorId, Pageable pageable);
+    Slice<Post> findPostListByUserIdLessThanOrderByIdDesc(@Param("userId") Long userId, @Param("cursorId") Long cursorId, Pageable pageable);
 }

--- a/src/main/java/naughty/tuzamate/domain/postLike/entity/PostLike.java
+++ b/src/main/java/naughty/tuzamate/domain/postLike/entity/PostLike.java
@@ -2,6 +2,7 @@ package naughty.tuzamate.domain.postLike.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import naughty.tuzamate.domain.community.CommunityItem;
 import naughty.tuzamate.domain.post.entity.Post;
 import naughty.tuzamate.domain.user.entity.User;
 
@@ -11,7 +12,7 @@ import naughty.tuzamate.domain.user.entity.User;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class PostLike {
+public class PostLike implements CommunityItem {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +25,15 @@ public class PostLike {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    @Override
+    public Long getCursorId() {
+        return this.id;
+    }
+
+    @Override
+    public Post getPost() {
+        return this.post;
+    }
 }
+

--- a/src/main/java/naughty/tuzamate/domain/postLike/repository/PostLikeRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/postLike/repository/PostLikeRepository.java
@@ -3,11 +3,22 @@ package naughty.tuzamate.domain.postLike.repository;
 import naughty.tuzamate.domain.post.entity.Post;
 import naughty.tuzamate.domain.postLike.entity.PostLike;
 import naughty.tuzamate.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     public boolean existsByPostAndUser(Post post, User user);
     public PostLike findByPostAndUser(Post post, User user);
 
+    // 커서가 없는 경우 최신순 조회
+    @Query("select pl from PostLike pl join fetch pl.post p where pl.user.id = :userId order by pl.id desc")
+    Slice<PostLike> findLikeListByUserIdOrderByIdDesc(@Param("userId") Long userId, Pageable pageable);
+
+    // 커서 있을 때 해당 커서 이전 데이터 최신순 조회
+    @Query("select pl from PostLike pl join fetch pl.post p where pl.user.id = :userId and pl.id < :cursorId order by pl.id desc")
+    Slice<PostLike> findLikeListByUserIdLessThanOrderByIdDesc(@Param("userId") Long userId, @Param("cursorId") Long cursorId, Pageable pageable);
 }

--- a/src/main/java/naughty/tuzamate/domain/postScrap/entity/PostScrap.java
+++ b/src/main/java/naughty/tuzamate/domain/postScrap/entity/PostScrap.java
@@ -2,6 +2,7 @@ package naughty.tuzamate.domain.postScrap.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import naughty.tuzamate.domain.community.CommunityItem;
 import naughty.tuzamate.domain.post.entity.Post;
 import naughty.tuzamate.domain.user.entity.User;
 
@@ -11,7 +12,7 @@ import naughty.tuzamate.domain.user.entity.User;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class PostScrap {
+public class PostScrap implements CommunityItem {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +25,14 @@ public class PostScrap {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    @Override
+    public Long getCursorId() {
+        return this.id;
+    }
+
+    @Override
+    public Post getPost() {
+        return this.post;
+    }
 }

--- a/src/main/java/naughty/tuzamate/domain/postScrap/repository/PostScrapRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/postScrap/repository/PostScrapRepository.java
@@ -2,12 +2,26 @@ package naughty.tuzamate.domain.postScrap.repository;
 
 import naughty.tuzamate.domain.post.entity.Post;
 import naughty.tuzamate.domain.postScrap.entity.PostScrap;
+import naughty.tuzamate.domain.profile.dto.response.ProfileResponseDTO;
 import naughty.tuzamate.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostScrapRepository extends JpaRepository<PostScrap, Long> {
 
     public boolean existsByPostAndUser(Post post, User user);
     public PostScrap findByPostAndUser(Post post, User user);
+
+    // 커서가 없는 경우 최신순 조회
+    @Query("select ps from PostScrap ps join fetch ps.post p where ps.user.id = :userId order by ps.id desc")
+    Slice<PostScrap> findScrapListByUserIdOrderByIdDesc(@Param("userId") Long userId, Pageable pageable);
+
+
+    // 커서 있을 때 해당 커서 이전 데이터 최신순 조회
+    @Query("select ps from PostScrap ps join fetch ps.post p where ps.user.id = :userId and ps.id < :cursorId order by ps.id desc")
+    Slice<PostScrap> findScrapListByUserIdLessThanOrderByIdDesc(@Param("userId") Long userId, @Param("cursorId") Long cursorId, Pageable pageable);
 
 }

--- a/src/main/java/naughty/tuzamate/domain/profile/controller/ProfileController.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/controller/ProfileController.java
@@ -81,4 +81,20 @@ public class ProfileController {
 
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, likeList);
     }
+
+    @GetMapping("/posts")
+    @Operation(summary = "작성한 게시글 조회")
+    @Parameters({
+            @Parameter(name = "cursor", description = "게시글 목록의 커서 값. 처음 조회 시 0을 입력", required = false, example = "0"),
+            @Parameter(name = "offset", description = "한 번에 가져올 게시글 개수. 기본 값은 10", required = false, example = "10")
+    })
+    public CustomResponse<?> getPostList(
+            @UserInfo User user,
+            @RequestParam(value = "cursor", defaultValue = "0") Long cursor,
+            @RequestParam(value = "offset", defaultValue = "10") int offset) {
+
+        ProfileResponseDTO.profileCommunityListResponse postList = profileQueryService.getPostList(user, cursor, offset);
+
+        return CustomResponse.onSuccess(GeneralSuccessCode.OK, postList);
+    }
 }

--- a/src/main/java/naughty/tuzamate/domain/profile/controller/ProfileController.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/controller/ProfileController.java
@@ -1,6 +1,8 @@
 package naughty.tuzamate.domain.profile.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import naughty.tuzamate.auth.principal.PrincipalDetails;
@@ -15,6 +17,7 @@ import naughty.tuzamate.domain.user.error.UserErrorCode;
 import naughty.tuzamate.global.annotation.UserInfo;
 import naughty.tuzamate.global.apiPayload.CustomResponse;
 import naughty.tuzamate.global.success.GeneralSuccessCode;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -41,12 +44,25 @@ public class ProfileController {
     public CustomResponse<?> getProfile(@UserInfo User user) {
 
         User getUser = profileQueryService.getProfile(user.getId());
-//        if (!getUser.getEmail().equals(userDetails.getUsername())) {
-//            // 현재 로그인한 사용자의 이메일과 조회하려는 사용자의 이메일이 다를 경우
-//            return CustomResponse.onFail(UserErrorCode.UNAUTHORIZED_USER);
-//        }
 
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, ProfileConverter.from(getUser));
-        
+
+    }
+
+    @GetMapping("/scraps")
+    @Operation(summary = "스크랩한 게시글 조회")
+    @Parameters({
+            @Parameter(name = "cursor", description = "스크랩 목록의 커서 값. 처음 조회 시 0을 입력", required = false, example = "0"),
+            @Parameter(name = "offset", description = "한 번에 가져올 스크랩 개수. 기본 값은 10", required = false, example = "10")
+    })
+    public CustomResponse<?> getScrapList(
+            @UserInfo User user,
+            @RequestParam(value = "cursor", defaultValue = "0") Long cursor,
+            @RequestParam(value = "offset", defaultValue = "10") int offset) {
+
+        ProfileResponseDTO.scrapListResponse scrapList = profileQueryService.getScrapList(user, cursor, offset);
+
+        return CustomResponse.onSuccess(GeneralSuccessCode.OK, scrapList);
+
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/profile/controller/ProfileController.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/controller/ProfileController.java
@@ -60,9 +60,25 @@ public class ProfileController {
             @RequestParam(value = "cursor", defaultValue = "0") Long cursor,
             @RequestParam(value = "offset", defaultValue = "10") int offset) {
 
-        ProfileResponseDTO.scrapListResponse scrapList = profileQueryService.getScrapList(user, cursor, offset);
+        ProfileResponseDTO.profileCommunityListResponse scrapList = profileQueryService.getScrapList(user, cursor, offset);
 
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, scrapList);
 
+    }
+
+    @GetMapping("/likes")
+    @Operation(summary = "좋아요한 게시글 조회")
+    @Parameters({
+            @Parameter(name = "cursor", description = "좋아요 목록의 커서 값. 처음 조회 시 0을 입력", required = false, example = "0"),
+            @Parameter(name = "offset", description = "한 번에 가져올 좋아요 개수. 기본 값은 10", required = false, example = "10")
+    })
+    public CustomResponse<?> getLikeList(
+            @UserInfo User user,
+            @RequestParam(value = "cursor", defaultValue = "0") Long cursor,
+            @RequestParam(value = "offset", defaultValue = "10") int offset) {
+
+        ProfileResponseDTO.profileCommunityListResponse likeList = profileQueryService.getLikeList(user, cursor, offset);
+
+        return CustomResponse.onSuccess(GeneralSuccessCode.OK, likeList);
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/profile/converter/ProfileConverter.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/converter/ProfileConverter.java
@@ -1,7 +1,13 @@
 package naughty.tuzamate.domain.profile.converter;
 
+import naughty.tuzamate.domain.post.entity.Post;
+import naughty.tuzamate.domain.postScrap.entity.PostScrap;
+import naughty.tuzamate.domain.profile.dto.request.ProfileRequestDTO;
 import naughty.tuzamate.domain.profile.dto.response.ProfileResponseDTO;
 import naughty.tuzamate.domain.user.entity.User;
+import org.springframework.data.domain.Slice;
+
+import java.util.ArrayList;
 
 public class ProfileConverter {
 
@@ -31,4 +37,25 @@ public class ProfileConverter {
                 .purpose(user.getPurpose())
                 .build();
     }
+
+    public static ProfileResponseDTO.scrapResponse toPostScrapResponseDTO(PostScrap postScrap) {
+
+        return ProfileResponseDTO.scrapResponse.builder()
+                .postId(postScrap.getId())
+                .title(postScrap.getPost().getTitle())
+                .contentPreview(postScrap.getPost().getContent().length() > 20 ? postScrap.getPost().getContent().substring(0, 20) + "..." : postScrap.getPost().getContent())
+                .build();
+    }
+
+    public static ProfileResponseDTO.scrapListResponse toScrapListResponse(Slice<PostScrap> postScraps) {
+        return ProfileResponseDTO.scrapListResponse.builder()
+                .scraps(postScraps.getContent().isEmpty() ? new ArrayList<>() :
+                        postScraps.getContent().stream()
+                                .map(postScrap -> toPostScrapResponseDTO(postScrap))
+                                .toList())
+                .hasNextPage(postScraps.hasNext())
+                .cursor(postScraps.getContent().isEmpty() ? 0L : postScraps.getContent().get(postScraps.getContent().size() - 1).getId())
+                .build();
+    }
+
 }

--- a/src/main/java/naughty/tuzamate/domain/profile/converter/ProfileConverter.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/converter/ProfileConverter.java
@@ -43,8 +43,8 @@ public class ProfileConverter {
 
         return ProfileResponseDTO.profileCommunityResponse.builder()
                 .postId(post.getId())
-                .title(post.getPost().getTitle())
-                .contentPreview(post.getPost().getContent().length() > 20 ? post.getPost().getContent().substring(0, 20) + "..." : post.getPost().getContent())
+                .title(post.getTitle())
+                .contentPreview(post.getContent().length() > 20 ? post.getContent().substring(0, 20) + "..." : post.getPost().getContent())
                 .build();
     }
 

--- a/src/main/java/naughty/tuzamate/domain/profile/converter/ProfileConverter.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/converter/ProfileConverter.java
@@ -1,5 +1,6 @@
 package naughty.tuzamate.domain.profile.converter;
 
+import naughty.tuzamate.domain.community.CommunityItem;
 import naughty.tuzamate.domain.post.entity.Post;
 import naughty.tuzamate.domain.postScrap.entity.PostScrap;
 import naughty.tuzamate.domain.profile.dto.request.ProfileRequestDTO;
@@ -38,23 +39,23 @@ public class ProfileConverter {
                 .build();
     }
 
-    public static ProfileResponseDTO.scrapResponse toPostScrapResponseDTO(PostScrap postScrap) {
+    public static ProfileResponseDTO.profileCommunityResponse toProfileCommunityDTO(Post post) {
 
-        return ProfileResponseDTO.scrapResponse.builder()
-                .postId(postScrap.getId())
-                .title(postScrap.getPost().getTitle())
-                .contentPreview(postScrap.getPost().getContent().length() > 20 ? postScrap.getPost().getContent().substring(0, 20) + "..." : postScrap.getPost().getContent())
+        return ProfileResponseDTO.profileCommunityResponse.builder()
+                .postId(post.getId())
+                .title(post.getPost().getTitle())
+                .contentPreview(post.getPost().getContent().length() > 20 ? post.getPost().getContent().substring(0, 20) + "..." : post.getPost().getContent())
                 .build();
     }
 
-    public static ProfileResponseDTO.scrapListResponse toScrapListResponse(Slice<PostScrap> postScraps) {
-        return ProfileResponseDTO.scrapListResponse.builder()
-                .scraps(postScraps.getContent().isEmpty() ? new ArrayList<>() :
-                        postScraps.getContent().stream()
-                                .map(postScrap -> toPostScrapResponseDTO(postScrap))
+    public static <T extends CommunityItem> ProfileResponseDTO.profileCommunityListResponse toProfileCommunityListDTO(Slice<T> slice) {
+        return ProfileResponseDTO.profileCommunityListResponse.builder()
+                .scraps(slice.getContent().isEmpty() ? new ArrayList<>() :
+                        slice.getContent().stream()
+                                .map(item -> ProfileConverter.toProfileCommunityDTO(item.getPost()))
                                 .toList())
-                .hasNextPage(postScraps.hasNext())
-                .cursor(postScraps.getContent().isEmpty() ? 0L : postScraps.getContent().get(postScraps.getContent().size() - 1).getId())
+                .hasNextPage(slice.hasNext())
+                .cursor(slice.getContent().isEmpty() ? 0L : slice.getContent().get(slice.getContent().size() - 1).getCursorId())
                 .build();
     }
 

--- a/src/main/java/naughty/tuzamate/domain/profile/dto/response/ProfileResponseDTO.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/dto/response/ProfileResponseDTO.java
@@ -1,6 +1,10 @@
 package naughty.tuzamate.domain.profile.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
 
 public class ProfileResponseDTO {
 
@@ -26,6 +30,21 @@ public class ProfileResponseDTO {
             Long expected_loss,
             String purpose
     ) {}
+
+    @Builder
+    public record scrapResponse(
+            Long postId,
+            String title,
+            String contentPreview
+    ) {}
+
+    @Builder
+    public record scrapListResponse(
+            List<scrapResponse> scraps,
+            boolean hasNextPage,
+            Long cursor
+    ) {}
+
 
 
 }

--- a/src/main/java/naughty/tuzamate/domain/profile/dto/response/ProfileResponseDTO.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/dto/response/ProfileResponseDTO.java
@@ -32,15 +32,15 @@ public class ProfileResponseDTO {
     ) {}
 
     @Builder
-    public record scrapResponse(
+    public record profileCommunityResponse(
             Long postId,
             String title,
             String contentPreview
     ) {}
 
     @Builder
-    public record scrapListResponse(
-            List<scrapResponse> scraps,
+    public record profileCommunityListResponse(
+            List<profileCommunityResponse> scraps,
             boolean hasNextPage,
             Long cursor
     ) {}

--- a/src/main/java/naughty/tuzamate/domain/profile/error/ProfileErrorCode.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/error/ProfileErrorCode.java
@@ -1,0 +1,21 @@
+package naughty.tuzamate.domain.profile.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import naughty.tuzamate.global.error.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+
+@AllArgsConstructor
+@Getter
+public enum ProfileErrorCode implements BaseErrorCode {
+
+    SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "PROFILE40402", "스크랩을 찾을 수 없습니다."),
+    INVALID_PROFILE_UPDATE(HttpStatus.BAD_REQUEST, "PROFILE40001", "프로필 업데이트에 실패했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/naughty/tuzamate/domain/profile/error/exception/ProfileCustomException.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/error/exception/ProfileCustomException.java
@@ -1,0 +1,13 @@
+package naughty.tuzamate.domain.profile.error.exception;
+
+import lombok.Getter;
+import naughty.tuzamate.global.error.BaseErrorCode;
+import naughty.tuzamate.global.error.exception.CustomException;
+
+@Getter
+public class ProfileCustomException extends CustomException {
+
+    public ProfileCustomException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/naughty/tuzamate/domain/profile/service/query/ProfileQueryService.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/service/query/ProfileQueryService.java
@@ -1,6 +1,8 @@
 package naughty.tuzamate.domain.profile.service.query;
 
 import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.domain.post.entity.Post;
+import naughty.tuzamate.domain.post.repository.PostRepository;
 import naughty.tuzamate.domain.postLike.entity.PostLike;
 import naughty.tuzamate.domain.postLike.repository.PostLikeRepository;
 import naughty.tuzamate.domain.postScrap.entity.PostScrap;
@@ -25,6 +27,7 @@ public class ProfileQueryService {
     private final UserRepository userRepository;
     private final PostScrapRepository postScrapRepository;
     private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
 
     public User getProfile(Long userId) {
 
@@ -58,5 +61,19 @@ public class ProfileQueryService {
         }
 
         return ProfileConverter.toProfileCommunityListDTO(postLikes);
+    }
+
+    public ProfileResponseDTO.profileCommunityListResponse getPostList(User user, Long cursor, int offset) {
+        Pageable pageable = PageRequest.of(0, offset);
+
+        Slice<Post> posts = null;
+
+        if (cursor == 0) {
+            posts = postRepository.findPostListByUserIdOrderByIdDesc(user.getId(), pageable);
+        } else {
+            posts = postRepository.findPostListByUserIdLessThanOrderByIdDesc(user.getId(), cursor, pageable);
+        }
+
+        return ProfileConverter.toProfileCommunityListDTO(posts);
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/profile/service/query/ProfileQueryService.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/service/query/ProfileQueryService.java
@@ -1,6 +1,8 @@
 package naughty.tuzamate.domain.profile.service.query;
 
 import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.domain.postLike.entity.PostLike;
+import naughty.tuzamate.domain.postLike.repository.PostLikeRepository;
 import naughty.tuzamate.domain.postScrap.entity.PostScrap;
 import naughty.tuzamate.domain.postScrap.repository.PostScrapRepository;
 import naughty.tuzamate.domain.profile.converter.ProfileConverter;
@@ -22,13 +24,14 @@ public class ProfileQueryService {
 
     private final UserRepository userRepository;
     private final PostScrapRepository postScrapRepository;
+    private final PostLikeRepository postLikeRepository;
 
     public User getProfile(Long userId) {
 
         return userRepository.findById(userId).orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
     }
 
-    public ProfileResponseDTO.scrapListResponse getScrapList(User user, Long cursor, int offset) {
+    public ProfileResponseDTO.profileCommunityListResponse getScrapList(User user, Long cursor, int offset) {
 
         Pageable pageable = PageRequest.of(0, offset);
 
@@ -40,6 +43,20 @@ public class ProfileQueryService {
             postScraps = postScrapRepository.findScrapListByUserIdLessThanOrderByIdDesc(user.getId(), cursor, pageable);
         }
 
-        return ProfileConverter.toScrapListResponse(postScraps);
+        return ProfileConverter.toProfileCommunityListDTO(postScraps);
+    }
+
+    public ProfileResponseDTO.profileCommunityListResponse getLikeList(User user, Long cursor, int offset) {
+        Pageable pageable = PageRequest.of(0, offset);
+
+        Slice<PostLike> postLikes = null;
+
+        if (cursor == 0) {
+            postLikes = postLikeRepository.findLikeListByUserIdOrderByIdDesc(user.getId(), pageable);
+        } else {
+            postLikes = postLikeRepository.findLikeListByUserIdLessThanOrderByIdDesc(user.getId(), cursor, pageable);
+        }
+
+        return ProfileConverter.toProfileCommunityListDTO(postLikes);
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/profile/service/query/ProfileQueryService.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/service/query/ProfileQueryService.java
@@ -1,11 +1,17 @@
 package naughty.tuzamate.domain.profile.service.query;
 
 import lombok.RequiredArgsConstructor;
-import naughty.tuzamate.domain.profile.repository.ProfileRepository;
+import naughty.tuzamate.domain.postScrap.entity.PostScrap;
+import naughty.tuzamate.domain.postScrap.repository.PostScrapRepository;
+import naughty.tuzamate.domain.profile.converter.ProfileConverter;
+import naughty.tuzamate.domain.profile.dto.response.ProfileResponseDTO;
 import naughty.tuzamate.domain.user.entity.User;
 import naughty.tuzamate.domain.user.error.UserErrorCode;
 import naughty.tuzamate.domain.user.error.exception.UserCustomException;
 import naughty.tuzamate.domain.user.repository.UserRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,11 +20,26 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ProfileQueryService {
 
-    private final ProfileRepository profileRepository;
     private final UserRepository userRepository;
+    private final PostScrapRepository postScrapRepository;
 
     public User getProfile(Long userId) {
 
         return userRepository.findById(userId).orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    public ProfileResponseDTO.scrapListResponse getScrapList(User user, Long cursor, int offset) {
+
+        Pageable pageable = PageRequest.of(0, offset);
+
+        Slice<PostScrap> postScraps = null;
+
+        if (cursor == 0) {
+            postScraps = postScrapRepository.findScrapListByUserIdOrderByIdDesc(user.getId(), pageable);
+        } else {
+            postScraps = postScrapRepository.findScrapListByUserIdLessThanOrderByIdDesc(user.getId(), cursor, pageable);
+        }
+
+        return ProfileConverter.toScrapListResponse(postScraps);
     }
 }

--- a/src/test/java/naughty/tuzamate/domain/profile/service/query/ProfileQueryServiceTest.java
+++ b/src/test/java/naughty/tuzamate/domain/profile/service/query/ProfileQueryServiceTest.java
@@ -61,15 +61,15 @@ class ProfileQueryServiceTest {
         when(postScrapRepository.findScrapListByUserIdLessThanOrderByIdDesc(eq(user.getId()), eq(cursor), any()))
                 .thenReturn(postScraps);
 
-        ProfileResponseDTO.scrapListResponse expectedResponse = new ProfileResponseDTO.scrapListResponse(List.of(), false, 5L);
+        ProfileResponseDTO.profileCommunityListResponse expectedResponse = new ProfileResponseDTO.profileCommunityListResponse(List.of(), false, 5L);
 
         try (MockedStatic<ProfileConverter> mocked =
                      mockStatic(ProfileConverter.class)) {
-            mocked.when(() -> ProfileConverter.toScrapListResponse(postScraps))
+            mocked.when(() -> ProfileConverter.toProfileCommunityListDTO(postScraps))
                     .thenReturn(expectedResponse);
 
             // when
-            ProfileResponseDTO.scrapListResponse actualResponse = profileQueryService.getScrapList(user, cursor, offset);
+            ProfileResponseDTO.profileCommunityListResponse actualResponse = profileQueryService.getScrapList(user, cursor, offset);
 
             // then
             Assertions.assertThat(actualResponse).isSameAs(expectedResponse);
@@ -102,7 +102,7 @@ class ProfileQueryServiceTest {
                 .thenReturn(postScraps);
 
         // when
-        ProfileResponseDTO.scrapListResponse actualResponse = profileQueryService.getScrapList(user, cursor, offset);
+        ProfileResponseDTO.profileCommunityListResponse actualResponse = profileQueryService.getScrapList(user, cursor, offset);
 
         // then
         Assertions.assertThat(actualResponse.scraps())

--- a/src/test/java/naughty/tuzamate/domain/profile/service/query/ProfileQueryServiceTest.java
+++ b/src/test/java/naughty/tuzamate/domain/profile/service/query/ProfileQueryServiceTest.java
@@ -1,0 +1,118 @@
+package naughty.tuzamate.domain.profile.service.query;
+
+import naughty.tuzamate.domain.post.entity.Post;
+import naughty.tuzamate.domain.postScrap.entity.PostScrap;
+import naughty.tuzamate.domain.postScrap.repository.PostScrapRepository;
+import naughty.tuzamate.domain.profile.converter.ProfileConverter;
+import naughty.tuzamate.domain.profile.dto.response.ProfileResponseDTO;
+import naughty.tuzamate.domain.user.entity.User;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+import static org.awaitility.Awaitility.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileQueryServiceTest {
+
+    @Mock
+    private PostScrapRepository postScrapRepository;
+
+    @InjectMocks
+    private ProfileQueryService profileQueryService;
+
+    @Test
+    @DisplayName("cursor != 0 일 때 scrapList 조회")
+    void scrapList_cursor_positive() {
+
+        // given
+        // 유저 생성
+        User user = User.builder().id(1L).build();
+
+        // 옵셋 및 cursor 설정
+        int offset = 10;
+        Long cursor = 5L;
+
+
+        SliceImpl<PostScrap> postScraps = new SliceImpl<>(
+                List.of(
+                        PostScrap.builder().id(1L).post(Post.builder().id(1L).title("title1").content("content1").build()).build(),
+                        PostScrap.builder().id(2L).post(Post.builder().id(2L).title("title2").content("content2").build()).build()
+                ),
+                PageRequest.of(0, offset),
+                false
+        );
+
+        when(postScrapRepository.findScrapListByUserIdLessThanOrderByIdDesc(eq(user.getId()), eq(cursor), any()))
+                .thenReturn(postScraps);
+
+        ProfileResponseDTO.scrapListResponse expectedResponse = new ProfileResponseDTO.scrapListResponse(List.of(), false, 5L);
+
+        try (MockedStatic<ProfileConverter> mocked =
+                     mockStatic(ProfileConverter.class)) {
+            mocked.when(() -> ProfileConverter.toScrapListResponse(postScraps))
+                    .thenReturn(expectedResponse);
+
+            // when
+            ProfileResponseDTO.scrapListResponse actualResponse = profileQueryService.getScrapList(user, cursor, offset);
+
+            // then
+            Assertions.assertThat(actualResponse).isSameAs(expectedResponse);
+        }
+
+    }
+
+    @Test
+    @DisplayName("cursor != 0일 때 scrapList 조회 - 실제 동작")
+    void scrapList_cursor_positive_real() {
+
+        // given
+        // 유저 생성
+        User user = User.builder().id(1L).build();
+
+        // 옵셋 및 cursor 설정
+        int offset = 10;
+        Long cursor = 5L;
+
+        SliceImpl<PostScrap> postScraps = new SliceImpl<>(
+                List.of(
+                        PostScrap.builder().id(1L).post(Post.builder().id(1L).title("title1").content("content1").build()).build(),
+                        PostScrap.builder().id(2L).post(Post.builder().id(2L).title("title2").content("content2").build()).build()
+                ),
+                PageRequest.of(0, offset),
+                false
+        );
+
+        when(postScrapRepository.findScrapListByUserIdLessThanOrderByIdDesc(eq(user.getId()), eq(cursor), any()))
+                .thenReturn(postScraps);
+
+        // when
+        ProfileResponseDTO.scrapListResponse actualResponse = profileQueryService.getScrapList(user, cursor, offset);
+
+        // then
+        Assertions.assertThat(actualResponse.scraps())
+                .extracting("postId", "title", "contentPreview")
+                .containsExactly(
+                        Tuple.tuple(1L, "title1", "content1"),
+                        Tuple.tuple(2L, "title2", "content2")
+                );
+
+        Assertions.assertThat(actualResponse.hasNextPage()).isFalse();
+        Assertions.assertThat(actualResponse.cursor()).isEqualTo(2L); // 마지막 PostScrap의 id가 2이므로 cursor는 2L이어야 함
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #42 

## 📌 개요
- 스크랩 게시글 목록 확인
- 좋아요 게시글 목록 확인
- 작성한 게시글 목록 확인

## 🔁 변경 사항
스크랩 - cf4398b1c9ba6b66247acfee12ff6dff61cc175c
좋아요 - fa30611d520c562ee7e73c6c24017eda393038dc
작성한 게시글 - d0ae88cd3d4884ef190fff626977d86754e11da1

세가지 모두 title과 contentPreview만 보여주는 방식이기에 Converter에서 다루는 부분은 동일
따라서 공통 인터페이스(CommunityItem)을 구현하도록 해서 Converter 제너릭으로 통일시킴 - refactoring fdacecec7052be133e8116bee548b1a7327e5d62
## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] PR에 적절한 라벨을 선택
- [x] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)
- 3가지 모두 같은 기능의 로직이라서 스크랩 확인하는 부분만 테스트 코드를 작성함

- 현재 컨트롤러에 ```@UserInfo```를 사용했지만 userId가 필요한 경우 또 user.getId()를 해야하는 경우가 있기에,
userId를 나타내는 어노테이션 구성 예정 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added endpoints to view a user's scraped posts, liked posts, and authored posts with cursor-based pagination in the profile section.
  * Introduced unified response formats for community-related lists in user profiles, including post previews and pagination info.
  * Added error handling for profile-related actions with clear error messages.

* **Bug Fixes**
  * Improved pagination logic for fetching user scraps, likes, and posts to ensure accurate cursor-based navigation.

* **Tests**
  * Added tests to verify correct behavior of paginated scrap list retrieval in user profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->