### PR TITLE
Refactor : 댓글 및 대댓글 목록 조회 페이지네이션 및 게시글 삭제 시 좋아요, 스크랩 동시 삭제 처리 기능 추가

### DIFF
--- a/src/main/java/naughty/tuzamate/domain/comment/controller/CommentController.java
+++ b/src/main/java/naughty/tuzamate/domain/comment/controller/CommentController.java
@@ -1,32 +1,46 @@
 package naughty.tuzamate.domain.comment.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.principal.PrincipalDetails;
 import naughty.tuzamate.domain.comment.dto.CommentReqDTO;
 import naughty.tuzamate.domain.comment.dto.CommentResDTO;
 import naughty.tuzamate.domain.comment.service.command.CommentCommandService;
 import naughty.tuzamate.domain.comment.service.query.CommentQueryService;
 import naughty.tuzamate.global.apiPayload.CustomResponse;
 import naughty.tuzamate.global.success.GeneralSuccessCode;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")
+@Tag(name = "댓글 컨트롤러", description = "댓글 관련 API")
 public class CommentController {
 
     private final CommentCommandService commentCommandService;
     private final CommentQueryService commentQueryService;
 
     @PostMapping("{postId}/comments")
+    @Operation(summary = "댓글 및 대댓글 생성",
+            description = "게시글에 댓글을 달거나, 현재 존재하는 댓글 밑에 대댓글을 다는 기능을 수행합니다.")
     public CustomResponse<CommentResDTO.CreateCommentResponseDTO> createComment(
-            @RequestBody CommentReqDTO.CreateCommentRequestDTO reqDTO) {
-        CommentResDTO.CreateCommentResponseDTO resDTO = commentCommandService.createComment(reqDTO);
+            @PathVariable Long postId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody CommentReqDTO.CreateCommentRequestDTO reqDTO
+    ) {
+        CommentResDTO.CreateCommentResponseDTO resDTO = commentCommandService
+                .createComment(reqDTO, postId, principalDetails);
 
         return CustomResponse.onSuccess(GeneralSuccessCode.CREATED, resDTO);
     }
 
     @GetMapping("{postId}/comments/{commentId}")
+    @Operation(summary = "댓글 및 대댓글 단일 조회",
+            description = "현재 존재하는 댓글 및 대댓글을 조회하는 기능을 수행합니다.")
     public CustomResponse<CommentResDTO.CommentPreviewDTO> getComment(
+            @PathVariable Long postId,
             @PathVariable Long commentId) {
         CommentResDTO.CommentPreviewDTO resDTO = commentQueryService.getComment(commentId);
 
@@ -34,13 +48,21 @@ public class CommentController {
     }
 
     @GetMapping("{postId}/comments")
-    public CustomResponse<CommentResDTO.CommentPreviewListDTO> getCommentList(@PathVariable Long postId) {
-        CommentResDTO.CommentPreviewListDTO resDTO = commentQueryService.getCommentList(postId);
+    @Operation(summary = "댓글 및 대댓글 목록 조회",
+            description = "게시글을 선택했을 때 현재 존재하는 댓글 및 대댓글 목록을 조회하는 기능을 수행합니다.")
+    public CustomResponse<CommentResDTO.CommentPreviewListDTO> getCommentList(
+            @PathVariable Long postId,
+             @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        CommentResDTO.CommentPreviewListDTO resDTO = commentQueryService.getCommentList(postId, cursor, size);
 
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, resDTO);
     }
 
     @PatchMapping("/{postId}/comments/{commentId}")
+    @Operation(summary = "댓글 및 대댓글 수정",
+            description = "현재 존재하는 댓글 및 대댓글을 수정하는 기능을 수행합니다.")
     public CustomResponse<CommentResDTO.UpdateCommentResponseDTO> updateComment(
             @PathVariable Long commentId,
             @RequestBody CommentReqDTO.UpdateCommentRequestDTO reqDTO) {
@@ -50,6 +72,8 @@ public class CommentController {
     }
 
     @DeleteMapping("/{postId}/comments/{commentId}")
+    @Operation(summary = "댓글 및 대댓글 삭제",
+            description = "현재 존재하는 댓글 및 대댓글을 삭제하는 기능을 수행합니다.")
     public CustomResponse<CommentResDTO.DeleteCommentResponseDTO> deleteComment(@PathVariable Long commentId) {
         CommentResDTO.DeleteCommentResponseDTO resDTO = commentCommandService.deleteComment(commentId);
 

--- a/src/main/java/naughty/tuzamate/domain/comment/converter/CommentConverter.java
+++ b/src/main/java/naughty/tuzamate/domain/comment/converter/CommentConverter.java
@@ -35,26 +35,29 @@ public class CommentConverter {
     }
 
     // Comment Entity -> CommentPreviewDTO
-    public static CommentResDTO.CommentPreviewDTO toCommentPreviewDTO(Comment comment) {
+    public static CommentResDTO.CommentPreviewDTO toCommentPreviewDTO(Comment comment, List<Comment> children) {
         return CommentResDTO.CommentPreviewDTO.builder()
                 .id(comment.getId())
                 .postId(comment.getPost().getId())
-                .parentId(comment.getParent().getId())
+                .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
                 .content(comment.getContent())
                 .writerName(comment.getUser().getNickname())
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())
+                .children(children.stream()
+                        .map(child -> toCommentPreviewDTO(child, List.of()))
+                        .collect(Collectors.toList()))
                 .build();
     }
 
     // List<Comment> -> CommentPreviewListDTO
-    public static CommentResDTO.CommentPreviewListDTO toCommentPreviewListDTO(List<Comment> comments) {
-
-        List<CommentResDTO.CommentPreviewDTO> commentPreviewDTOS = comments.stream()
-                .map(CommentConverter::toCommentPreviewDTO).collect(Collectors.toList());
+    public static CommentResDTO.CommentPreviewListDTO toCommentPreviewListDTO(
+            List<CommentResDTO.CommentPreviewDTO> previewList, boolean hasNext, Long nextCursor) {
 
         return CommentResDTO.CommentPreviewListDTO.builder()
-                .commentPreviewListDTO(commentPreviewDTOS)
+                .commentPreviewListDTO(previewList)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
                 .build();
     }
 

--- a/src/main/java/naughty/tuzamate/domain/comment/dto/CommentReqDTO.java
+++ b/src/main/java/naughty/tuzamate/domain/comment/dto/CommentReqDTO.java
@@ -9,9 +9,7 @@ public class CommentReqDTO {
     @Builder
     public record CreateCommentRequestDTO(
             String content,
-            Long userId,
-            Long postId,
-            Long parentId
+            Long parentId // null 인 경우 댓글, null 이 아닌 경우 대댓글
     ){}
 
     @Builder

--- a/src/main/java/naughty/tuzamate/domain/comment/dto/CommentResDTO.java
+++ b/src/main/java/naughty/tuzamate/domain/comment/dto/CommentResDTO.java
@@ -21,12 +21,15 @@ public class CommentResDTO {
             String content,
             String writerName,   // optional
             LocalDateTime createdAt,
-            LocalDateTime updatedAt
+            LocalDateTime updatedAt,
+            List<CommentPreviewDTO> children
     ) {}
 
     @Builder
     public record CommentPreviewListDTO(
-            List<CommentPreviewDTO> commentPreviewListDTO
+            List<CommentPreviewDTO> commentPreviewListDTO,
+            boolean hasNext,
+            Long nextCursor
     ){}
 
     @Builder

--- a/src/main/java/naughty/tuzamate/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,11 @@
 package naughty.tuzamate.domain.comment.repository;
 
 import naughty.tuzamate.domain.comment.entity.Comment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -9,4 +13,23 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     public List<Comment> findByPostId(Long postId);
 
+    // parent 댓글들 목록 조회
+    @Query("""
+        SELECT c
+        FROM Comment c
+        WHERE c.post.id = :postId
+          AND c.parent IS NULL
+          AND (:cursor IS NULL OR c.id > :cursor)
+        ORDER BY c.id ASC
+    """)
+    Slice<Comment> findRootCommentsCursorAsc(@Param("postId") Long postId, @Param("cursor") Long cursor, Pageable pageable);
+
+    // parent 댓글 id를 기준으로 child 댓글들 조회
+    @Query("""
+        SELECT c
+        FROM Comment c
+        WHERE c.parent.id IN :parentId
+        ORDER BY c.id ASC
+    """)
+    List<Comment> findChildrenInParentIds(@Param("parentId") List<Long> parentId);
 }

--- a/src/main/java/naughty/tuzamate/domain/comment/service/command/CommentCommandService.java
+++ b/src/main/java/naughty/tuzamate/domain/comment/service/command/CommentCommandService.java
@@ -1,10 +1,15 @@
 package naughty.tuzamate.domain.comment.service.command;
 
+import naughty.tuzamate.auth.principal.PrincipalDetails;
 import naughty.tuzamate.domain.comment.dto.CommentReqDTO;
 import naughty.tuzamate.domain.comment.dto.CommentResDTO;
 
 public interface CommentCommandService {
-    CommentResDTO.CreateCommentResponseDTO createComment(CommentReqDTO.CreateCommentRequestDTO reqDTO);
-    CommentResDTO.UpdateCommentResponseDTO updateComment(CommentReqDTO.UpdateCommentRequestDTO reqDTO, Long commentId);
+    CommentResDTO.CreateCommentResponseDTO createComment(
+            CommentReqDTO.CreateCommentRequestDTO reqDTO, Long postId, PrincipalDetails principalDetails);
+
+    CommentResDTO.UpdateCommentResponseDTO updateComment(
+            CommentReqDTO.UpdateCommentRequestDTO reqDTO, Long commentId);
+
     CommentResDTO.DeleteCommentResponseDTO deleteComment(Long commentId);
 }

--- a/src/main/java/naughty/tuzamate/domain/comment/service/command/CommentCommandServiceImpl.java
+++ b/src/main/java/naughty/tuzamate/domain/comment/service/command/CommentCommandServiceImpl.java
@@ -1,6 +1,7 @@
 package naughty.tuzamate.domain.comment.service.command;
 
 import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.principal.PrincipalDetails;
 import naughty.tuzamate.domain.comment.converter.CommentConverter;
 import naughty.tuzamate.domain.comment.dto.CommentReqDTO;
 import naughty.tuzamate.domain.comment.dto.CommentResDTO;
@@ -25,11 +26,13 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     private final PostRepository postRepository;
 
     @Override
-    public CommentResDTO.CreateCommentResponseDTO createComment(CommentReqDTO.CreateCommentRequestDTO reqDTO) {
-        User user = userRepository.findById(reqDTO.userId())
+    public CommentResDTO.CreateCommentResponseDTO createComment(
+            CommentReqDTO.CreateCommentRequestDTO reqDTO, Long postId, PrincipalDetails principalDetails
+    ) {
+        User user = userRepository.findById(principalDetails.getId())
                 .orElseThrow(() -> new CustomException(GeneralErrorCode.NOT_FOUND_404));
 
-        Post post = postRepository.findById(reqDTO.postId())
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(GeneralErrorCode.NOT_FOUND_404));
 
         Comment parent = null;

--- a/src/main/java/naughty/tuzamate/domain/comment/service/query/CommentQueryService.java
+++ b/src/main/java/naughty/tuzamate/domain/comment/service/query/CommentQueryService.java
@@ -4,5 +4,5 @@ import naughty.tuzamate.domain.comment.dto.CommentResDTO;
 
 public interface CommentQueryService {
     CommentResDTO.CommentPreviewDTO getComment(Long commentId);
-    CommentResDTO.CommentPreviewListDTO getCommentList(Long postId);
+    CommentResDTO.CommentPreviewListDTO getCommentList(Long postId, Long cursor, int size);
 }

--- a/src/main/java/naughty/tuzamate/domain/comment/service/query/CommentQueryServiceImpl.java
+++ b/src/main/java/naughty/tuzamate/domain/comment/service/query/CommentQueryServiceImpl.java
@@ -7,10 +7,15 @@ import naughty.tuzamate.domain.comment.entity.Comment;
 import naughty.tuzamate.domain.comment.repository.CommentRepository;
 import naughty.tuzamate.global.error.GeneralErrorCode;
 import naughty.tuzamate.global.error.exception.CustomException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -24,13 +29,33 @@ public class CommentQueryServiceImpl implements CommentQueryService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomException(GeneralErrorCode.NOT_FOUND_404));
 
-        return CommentConverter.toCommentPreviewDTO(comment);
+        return CommentConverter.toCommentPreviewDTO(comment, List.of());
     }
 
     @Override
-    public CommentResDTO.CommentPreviewListDTO getCommentList(Long postId) {
-        List<Comment> comments = commentRepository.findByPostId(postId);
+    public CommentResDTO.CommentPreviewListDTO getCommentList(Long postId, Long cursor, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+        Slice<Comment> rootSlice = commentRepository.findRootCommentsCursorAsc(postId, cursor, pageable);
 
-        return CommentConverter.toCommentPreviewListDTO(comments);
+        List<Comment> roots = rootSlice.getContent();
+
+        List<Long> parentIds = roots.stream()
+                .map(Comment::getId)
+                .toList();
+
+        Map<Long, List<Comment>> childMap = commentRepository. findChildrenInParentIds(parentIds)
+                .stream()
+                .collect(Collectors.groupingBy(c -> c.getParent().getId()));
+
+        List<CommentResDTO.CommentPreviewDTO> dtoList = roots.stream()
+                .map(root -> CommentConverter.toCommentPreviewDTO(root, childMap.getOrDefault(root.getId(),List.of()))).toList();
+
+        Long nextCursor = rootSlice.hasNext()
+                ? dtoList.get(dtoList.size() - 1).id()
+                : null;
+
+        return CommentConverter.toCommentPreviewListDTO(dtoList,
+                rootSlice.hasNext(),
+                nextCursor);
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/post/controller/PostController.java
+++ b/src/main/java/naughty/tuzamate/domain/post/controller/PostController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-
 @Tag(name = "게시판 컨트롤러", description = "게시판 관련 API")
 public class PostController {
 

--- a/src/main/java/naughty/tuzamate/domain/post/entity/Post.java
+++ b/src/main/java/naughty/tuzamate/domain/post/entity/Post.java
@@ -5,6 +5,7 @@ import lombok.*;
 import naughty.tuzamate.domain.comment.entity.Comment;
 import naughty.tuzamate.domain.post.enums.BoardType;
 import naughty.tuzamate.domain.postLike.entity.PostLike;
+import naughty.tuzamate.domain.postScrap.entity.PostScrap;
 import naughty.tuzamate.global.BaseTimeEntity;
 import naughty.tuzamate.domain.user.entity.User;
 
@@ -39,6 +40,12 @@ public class Post extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostLike> postLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostScrap> postScraps = new ArrayList<>();
 
     public void updateTitle(String title) {
         this.title = title;

--- a/src/main/java/naughty/tuzamate/domain/post/entity/Post.java
+++ b/src/main/java/naughty/tuzamate/domain/post/entity/Post.java
@@ -37,7 +37,7 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
     public void updateTitle(String title) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #46 

## 📌 개요
- 댓글 및 대댓글 목록 조회 페이지네이션
- 게시글 삭제 시 좋아요, 스크랩 동시 삭제 처리 기능 추가

## 🔁 변경 사항
- Post(양방향 매핑으로 postLikes, postScraps 추가)
- PostController -> cursor, size 추가
- PostRepository -> 커서 페이지네이션 쿼리문 추가
- PostQueryService -> 커서 페이지네이션에 맞는 코드로 수정

## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [x] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for paginated comment retrieval with cursor-based navigation and metadata (hasNext, nextCursor).
  * Comment responses now include nested (child) comments for improved thread visibility.
  * Enhanced API documentation for comment-related endpoints.

* **Improvements**
  * Comment creation now automatically associates the comment with the authenticated user and the specified post.
  * Simplified comment creation requests by removing unnecessary fields.

* **Other Changes**
  * Improved management of related entities for posts, including automatic handling of likes, scraps, and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->