### PR TITLE
Feat: 프로필 초기 설정

### DIFF
--- a/src/main/java/naughty/tuzamate/domain/profile/controller/ProfileController.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/controller/ProfileController.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import naughty.tuzamate.domain.profile.converter.ProfileConverter;
 import naughty.tuzamate.domain.profile.dto.request.ProfileRequestDTO;
 import naughty.tuzamate.domain.profile.dto.response.ProfileResponseDTO;
 import naughty.tuzamate.domain.profile.service.command.ProfileCommandService;
 import naughty.tuzamate.domain.profile.service.query.ProfileQueryService;
+import naughty.tuzamate.domain.user.dto.UserInitProfileRequestDTO;
 import naughty.tuzamate.domain.user.entity.User;
 import naughty.tuzamate.auth.annotation.UserInfo;
 import naughty.tuzamate.global.apiPayload.CustomResponse;
@@ -24,6 +26,19 @@ public class ProfileController {
 
     private final ProfileCommandService profileCommandService;
     private final ProfileQueryService profileQueryService;
+
+    @PostMapping("/init-profile")
+    @Operation(summary = "프로필 초기 설정", description = "닉네임, 재테크 수준을 받아 초기 프로필을 설정한다.")
+    public CustomResponse<?> initProfile(
+            @UserInfo User user,
+            @Valid @RequestBody UserInitProfileRequestDTO requestDTO) {
+
+        ProfileResponseDTO.profileInitResponse response = profileCommandService.initProfile(user, requestDTO);
+
+        return CustomResponse.onSuccess(GeneralSuccessCode.CREATED, response);
+
+    }
+
 
     @PutMapping("/{userId}")
     @Operation(summary = "프로필 수정")

--- a/src/main/java/naughty/tuzamate/domain/profile/converter/ProfileConverter.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/converter/ProfileConverter.java
@@ -23,7 +23,7 @@ public class ProfileConverter {
 
         return ProfileResponseDTO.getProfileResponse.builder()
                 .age(user.getAge())
-                .experience(user.isExperience())
+                .experience(user.getExperience())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .funding_situation(user.getFundingSituation())

--- a/src/main/java/naughty/tuzamate/domain/profile/dto/request/ProfileRequestDTO.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/dto/request/ProfileRequestDTO.java
@@ -6,7 +6,7 @@ public record ProfileRequestDTO(
     @NotNull(message = "나이를 입력해주세요")
     Long age,
     @NotNull(message = "투자 경험을 입력해주세요")
-    boolean experience,
+    String experience,
     @NotNull(message = "닉네임을 입력해주세요")
     String nickname,
     @NotNull(message = "자금 상황을 입력해주세요")

--- a/src/main/java/naughty/tuzamate/domain/profile/dto/response/ProfileResponseDTO.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/dto/response/ProfileResponseDTO.java
@@ -2,6 +2,8 @@ package naughty.tuzamate.domain.profile.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import naughty.tuzamate.domain.user.dto.UserInitProfileRequestDTO;
+import naughty.tuzamate.domain.user.entity.User;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
@@ -16,7 +18,7 @@ public class ProfileResponseDTO {
     @Builder
     public record getProfileResponse(
             Long age,
-            boolean experience,
+            String experience,
             String email,
             String nickname,
             String funding_situation,
@@ -44,6 +46,15 @@ public class ProfileResponseDTO {
             boolean hasNextPage,
             Long cursor
     ) {}
+
+    public record profileInitResponse(
+            String nickname,
+            String experience
+    ) {
+        public static profileInitResponse of(User user) {
+            return new profileInitResponse(user.getNickname(), user.getExperience());
+        }
+    }
 
 
 

--- a/src/main/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandService.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandService.java
@@ -2,7 +2,9 @@ package naughty.tuzamate.domain.profile.service.command;
 
 import lombok.RequiredArgsConstructor;
 import naughty.tuzamate.domain.profile.dto.request.ProfileRequestDTO;
+import naughty.tuzamate.domain.profile.dto.response.ProfileResponseDTO;
 import naughty.tuzamate.domain.profile.repository.ProfileRepository;
+import naughty.tuzamate.domain.user.dto.UserInitProfileRequestDTO;
 import naughty.tuzamate.domain.user.entity.User;
 import naughty.tuzamate.domain.user.error.UserErrorCode;
 import naughty.tuzamate.domain.user.error.exception.UserCustomException;
@@ -24,5 +26,16 @@ public class ProfileCommandService {
         user.updateNickname(requestDTO.nickname());
 
         return user;
+    }
+
+    public ProfileResponseDTO.profileInitResponse initProfile(User user, UserInitProfileRequestDTO dto) {
+
+        if (user.getNickname() != null || user.getExperience() != null) {
+            throw new UserCustomException(UserErrorCode.ALREADY_INIT_PROFILE);
+        }
+        user.initProfile(dto.nickname(), dto.experience());
+        userRepository.save(user);
+
+        return ProfileResponseDTO.profileInitResponse.of(user);
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandService.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandService.java
@@ -33,6 +33,11 @@ public class ProfileCommandService {
         if (user.getNickname() != null || user.getExperience() != null) {
             throw new UserCustomException(UserErrorCode.ALREADY_INIT_PROFILE);
         }
+
+        if (userRepository.existsByNickname(dto.nickname())) {
+            throw new UserCustomException(UserErrorCode.USER_NICKNAME_ALREADY_EXISTS);
+        }
+
         user.initProfile(dto.nickname(), dto.experience());
         userRepository.save(user);
 

--- a/src/main/java/naughty/tuzamate/domain/user/dto/UserInitProfileRequestDTO.java
+++ b/src/main/java/naughty/tuzamate/domain/user/dto/UserInitProfileRequestDTO.java
@@ -1,0 +1,12 @@
+package naughty.tuzamate.domain.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public record UserInitProfileRequestDTO(
+
+        @NotNull(message = "닉네임을 입력해주세요")
+        String nickname,
+        @NotNull(message = "재테크 수준을 입력해주세요")
+        String experience
+){}

--- a/src/main/java/naughty/tuzamate/domain/user/entity/User.java
+++ b/src/main/java/naughty/tuzamate/domain/user/entity/User.java
@@ -26,7 +26,7 @@ public class User extends BaseTimeEntity {
     private Long age;
 
     @Column(name = "investment_experience")
-    private boolean experience;
+    private String experience;
 
     private String email;
 
@@ -82,5 +82,9 @@ public class User extends BaseTimeEntity {
         this.nickname = nickname;
     }
 
+    public void initProfile(String nickname, String experience) {
+        this.nickname = nickname;
+        this.experience = experience;
+    }
 
 }

--- a/src/main/java/naughty/tuzamate/domain/user/error/UserErrorCode.java
+++ b/src/main/java/naughty/tuzamate/domain/user/error/UserErrorCode.java
@@ -18,7 +18,7 @@ public enum UserErrorCode implements BaseErrorCode {
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "USER401", "인증되지 않은 사용자입니다."),
     LOGGED_OUT_USER(HttpStatus.UNAUTHORIZED, "USER40101", "로그아웃된 사용자입니다. 다시 로그인 해주세요."),
     INVALID_USER_ID_FORMAT(HttpStatus.BAD_REQUEST, "USER40001", "유효하지 않은 사용자 ID 형식입니다."),
-
+    ALREADY_INIT_PROFILE(HttpStatus.BAD_REQUEST, "USER40002", "이미 프로필이 초기화되어 있습니다.")
     ;
 
 

--- a/src/main/java/naughty/tuzamate/domain/user/error/UserErrorCode.java
+++ b/src/main/java/naughty/tuzamate/domain/user/error/UserErrorCode.java
@@ -18,8 +18,8 @@ public enum UserErrorCode implements BaseErrorCode {
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "USER401", "인증되지 않은 사용자입니다."),
     LOGGED_OUT_USER(HttpStatus.UNAUTHORIZED, "USER40101", "로그아웃된 사용자입니다. 다시 로그인 해주세요."),
     INVALID_USER_ID_FORMAT(HttpStatus.BAD_REQUEST, "USER40001", "유효하지 않은 사용자 ID 형식입니다."),
-    ALREADY_INIT_PROFILE(HttpStatus.BAD_REQUEST, "USER40002", "이미 프로필이 초기화되어 있습니다.")
-    ;
+    ALREADY_INIT_PROFILE(HttpStatus.BAD_REQUEST, "USER40002", "이미 프로필이 초기화되어 있습니다."),
+    USER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER40902", "이미 존재하는 닉네임입니다."),;
 
 
     private final HttpStatus status;

--- a/src/main/java/naughty/tuzamate/domain/user/repository/UserRepository.java
+++ b/src/main/java/naughty/tuzamate/domain/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package naughty.tuzamate.domain.user.repository;
 
 import naughty.tuzamate.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -11,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/test/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandServiceTest.java
+++ b/src/test/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandServiceTest.java
@@ -1,0 +1,26 @@
+package naughty.tuzamate.domain.profile.service.command;
+
+import naughty.tuzamate.domain.user.dto.UserInitProfileRequestDTO;
+import naughty.tuzamate.domain.user.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProfileCommandServiceTest {
+
+    @Test
+    void initProfile() {
+
+        // given
+        User user = User.builder().id(1L).build();
+
+        // when
+        UserInitProfileRequestDTO dto = new UserInitProfileRequestDTO("nickname1", "beginner");
+        user.initProfile(dto.nickname(), dto.experience());
+
+        // then
+        Assertions.assertThat(user.getNickname()).isEqualTo("nickname1");
+        Assertions.assertThat(user.getExperience()).isEqualTo("beginner");
+    }
+}

--- a/src/test/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandServiceTest.java
+++ b/src/test/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandServiceTest.java
@@ -1,26 +1,44 @@
 package naughty.tuzamate.domain.profile.service.command;
 
+import naughty.tuzamate.domain.profile.dto.response.ProfileResponseDTO;
 import naughty.tuzamate.domain.user.dto.UserInitProfileRequestDTO;
 import naughty.tuzamate.domain.user.entity.User;
+import naughty.tuzamate.domain.user.repository.UserRepository;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static reactor.core.publisher.Mono.when;
 
 class ProfileCommandServiceTest {
 
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ProfileCommandService profileCommandService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
     @Test
     void initProfile() {
 
         // given
         User user = User.builder().id(1L).build();
+        UserInitProfileRequestDTO dto = new UserInitProfileRequestDTO("nickname1", "beginner");
 
         // when
-        UserInitProfileRequestDTO dto = new UserInitProfileRequestDTO("nickname1", "beginner");
-        user.initProfile(dto.nickname(), dto.experience());
+        ProfileResponseDTO.profileInitResponse response = profileCommandService.initProfile(user, dto);
 
         // then
-        Assertions.assertThat(user.getNickname()).isEqualTo("nickname1");
-        Assertions.assertThat(user.getExperience()).isEqualTo("beginner");
+        Assertions.assertThat(response.nickname()).isEqualTo(user.getNickname());
+        Assertions.assertThat(user.getExperience()).isEqualTo(user.getExperience());
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #51 

## 📌 개요
- User의 회원가입 이후 초기 세팅값을 입력 받는다 (username, experience - 재테크 수준)

## 🔁 변경 사항
- boolen experience 를 String experience로 변경
## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] PR에 적절한 라벨을 선택
- [x] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an endpoint for initial profile setup, allowing users to set their nickname and financial experience level.
  * Introduced validation for profile initialization inputs.
  * Added error handling for cases where a profile has already been initialized or nickname already exists.

* **Changes**
  * The "experience" field in user profiles is now a text value instead of a boolean.

* **Bug Fixes**
  * Improved profile data handling to prevent re-initialization.

* **Tests**
  * Added tests to verify profile initialization functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->