### PR TITLE
Refactor : profile 서비스 코드 삭제,principal 사용

### DIFF
--- a/src/main/java/naughty/tuzamate/auth/principal/PrincipalDetails.java
+++ b/src/main/java/naughty/tuzamate/auth/principal/PrincipalDetails.java
@@ -59,4 +59,8 @@ public class PrincipalDetails implements UserDetails {
     public boolean isCredentialsNonExpired() {
         return true;
     }
+
+    public User getUser() {
+        return user;
+    }
 }

--- a/src/main/java/naughty/tuzamate/auth/resolver/UserInfoResolver.java
+++ b/src/main/java/naughty/tuzamate/auth/resolver/UserInfoResolver.java
@@ -1,6 +1,7 @@
 package naughty.tuzamate.auth.resolver;
 
 import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.auth.principal.PrincipalDetails;
 import naughty.tuzamate.domain.user.entity.User;
 import naughty.tuzamate.domain.user.error.UserErrorCode;
 import naughty.tuzamate.domain.user.error.exception.UserCustomException;
@@ -32,12 +33,14 @@ public class UserInfoResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
 
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-            if (authentication != null && authentication.isAuthenticated()) {
-                String email = authentication.getName();
-                return userRepository.findByEmail(email)
-                        .orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
-            }
 
-        throw new UserCustomException(UserErrorCode.UNAUTHORIZED_USER);
+        // 인증 정보가 없거나 PrincipalDetails가 아닌 경우 예외 처리
+        if (authentication == null || !(authentication.getPrincipal() instanceof PrincipalDetails)) {
+            throw new UserCustomException(UserErrorCode.UNAUTHORIZED_USER);
+        }
+
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        return principalDetails.getUser();
+
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/profile/controller/ProfileController.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/controller/ProfileController.java
@@ -50,12 +50,10 @@ public class ProfileController {
     }
 
     @GetMapping("")
-    @Operation(summary = "프로필 조회")
+    @Operation(summary = "프로필 기본 조회")
     public CustomResponse<?> getProfile(@UserInfo User user) {
 
-        User getUser = profileQueryService.getProfile(user.getId());
-
-        return CustomResponse.onSuccess(GeneralSuccessCode.OK, ProfileConverter.from(getUser));
+        return CustomResponse.onSuccess(GeneralSuccessCode.OK, ProfileConverter.from(user));
 
     }
 

--- a/src/main/java/naughty/tuzamate/domain/profile/service/query/ProfileQueryService.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/service/query/ProfileQueryService.java
@@ -29,11 +29,6 @@ public class ProfileQueryService {
     private final PostLikeRepository postLikeRepository;
     private final PostRepository postRepository;
 
-    public User getProfile(Long userId) {
-
-        return userRepository.findById(userId).orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
-    }
-
     public ProfileResponseDTO.profileCommunityListResponse getScrapList(User user, Long cursor, int offset) {
 
         Pageable pageable = PageRequest.of(0, offset);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #55 

## 📌 개요
- profile servier에서의 불필요한 프로필 조회 코드 삭제
- user 정보 조회시 resolver에서 불필요한 db 조회 코드 삭제 및 principal 이용해 유저 정보 반환

## 🔁 변경 사항
- PrincipalDetails에서 유저 정보 반환 코드 추가 (getUser())

## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved user authentication handling for profile retrieval, allowing direct access to user information.
* **Refactor**
  * Streamlined profile retrieval logic for a simpler and more efficient process.
  * Updated API documentation summary for profile retrieval.
* **Chores**
  * Removed unused method for fetching user profiles by ID to reduce code redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->