### PR TITLE
Refactor: 프로필 조회 시 응답값 삭제 및 추가

### DIFF
--- a/src/main/java/naughty/tuzamate/domain/profile/converter/ProfileConverter.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/converter/ProfileConverter.java
@@ -22,20 +22,16 @@ public class ProfileConverter {
     public static ProfileResponseDTO.getProfileResponse from(User user) {
 
         return ProfileResponseDTO.getProfileResponse.builder()
-                .age(user.getAge())
-                .experience(user.getExperience())
-                .email(user.getEmail())
-                .nickname(user.getNickname())
-                .funding_situation(user.getFundingSituation())
-                .income(user.getIncome())
-                .stability(user.getStability())
-                .source(user.getSource())
-                .type(user.getType())
-                .proportion(user.getProportion())
-                .period(user.getPeriod())
-                .expected_income(user.getExpectedIncome())
-                .expected_loss(user.getExpectedLoss())
-                .purpose(user.getPurpose())
+                .myInfo(ProfileResponseDTO.MyInfo.builder()
+                        .nickname(user.getNickname())
+                        .gender(user.getGender())
+                        .email(user.getEmail())
+                        .build())
+                .investmentInfo(ProfileResponseDTO.InvestmentInfo.builder()
+                        .income(user.getIncome())
+                        .type(user.getType())
+                        .purpose(user.getProportion())
+                        .build())
                 .build();
     }
 

--- a/src/main/java/naughty/tuzamate/domain/profile/dto/response/ProfileResponseDTO.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/dto/response/ProfileResponseDTO.java
@@ -1,9 +1,11 @@
 package naughty.tuzamate.domain.profile.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import naughty.tuzamate.domain.user.dto.UserInitProfileRequestDTO;
 import naughty.tuzamate.domain.user.entity.User;
+import naughty.tuzamate.domain.user.enums.Gender;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
@@ -13,39 +15,31 @@ public class ProfileResponseDTO {
     @Builder
     public record updateProfileResponse(
             String nickname
-    ) {}
+    ) {
+    }
 
     @Builder
     public record getProfileResponse(
-            Long age,
-            String experience,
-            String email,
-            String nickname,
-            String funding_situation,
-            Long income,
-            String stability,
-            String source,
-            String type,
-            String proportion,
-            Long period,
-            Long expected_income,
-            Long expected_loss,
-            String purpose
-    ) {}
+            MyInfo myInfo,
+            InvestmentInfo investmentInfo
+    ) {
+    }
 
     @Builder
     public record profileCommunityResponse(
             Long postId,
             String title,
             String contentPreview
-    ) {}
+    ) {
+    }
 
     @Builder
     public record profileCommunityListResponse(
             List<profileCommunityResponse> scraps,
             boolean hasNextPage,
             Long cursor
-    ) {}
+    ) {
+    }
 
     public record profileInitResponse(
             String nickname,
@@ -56,6 +50,19 @@ public class ProfileResponseDTO {
         }
     }
 
+    @Builder
+    public record MyInfo(
+            String nickname,
+            Gender gender,
+            String email
+    ) {}
+
+    @Builder
+    public record InvestmentInfo(
+            Long income,
+            String type,
+            String purpose
+    ) { }
 
 
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #57 

## 📌 개요
- 불필요한 응답값은 삭제
- 응답값을 추가적인 dto로 감싸서 반환 (myInfo, investmentInfo)

## 🔁 변경 사항

## 📸 스크린샷
<img width="332" height="366" alt="image" src="https://github.com/user-attachments/assets/712ddb79-ab04-4c96-8fa3-d811c419253d" />

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * User profile response data is now organized into two sections: personal information and investment information, improving clarity and structure.
  * Some previously available details have been removed from the profile response.

* **Style**
  * Minor formatting improvements for consistency in the profile response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->