### PR TITLE
Feat : 회원 탈퇴 API

### DIFF
--- a/src/main/java/naughty/tuzamate/domain/profile/controller/ProfileController.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/controller/ProfileController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import naughty.tuzamate.auth.annotation.UserIdInfo;
 import naughty.tuzamate.domain.profile.converter.ProfileConverter;
+import naughty.tuzamate.domain.profile.dto.request.DeleteUserRequestDto;
 import naughty.tuzamate.domain.profile.dto.response.ProfileResponseDTO;
 import naughty.tuzamate.domain.profile.service.command.ProfileCommandService;
 import naughty.tuzamate.domain.profile.service.query.ProfileQueryService;
@@ -94,5 +95,13 @@ public class ProfileController {
         ProfileResponseDTO.profileCommunityListResponse postList = profileQueryService.getPostList(userId, cursor, offset);
 
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, postList);
+    }
+
+    @DeleteMapping
+    @Operation(summary = "프로필 삭제", description = "사용자의 프로필을 삭제한다.")
+    public CustomResponse<?> deleteProfile(@UserInfo User user, @Valid @RequestBody DeleteUserRequestDto dto) {
+
+        profileCommandService.deleteProfile(user, dto);
+        return CustomResponse.onSuccess(GeneralSuccessCode.DELETED, dto);
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/profile/dto/request/DeleteUserRequestDto.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/dto/request/DeleteUserRequestDto.java
@@ -1,0 +1,9 @@
+package naughty.tuzamate.domain.profile.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteUserRequestDto(
+        @NotNull(message = "탈퇴하기 위해 닉네임을 입력해야 합니다.")
+        String nickname
+) {
+}

--- a/src/main/java/naughty/tuzamate/domain/profile/error/ProfileErrorCode.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/error/ProfileErrorCode.java
@@ -12,7 +12,7 @@ public enum ProfileErrorCode implements BaseErrorCode {
 
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "PROFILE40402", "스크랩을 찾을 수 없습니다."),
     INVALID_PROFILE_UPDATE(HttpStatus.BAD_REQUEST, "PROFILE40001", "프로필 업데이트에 실패했습니다."),
-    ;
+    MISMATCHED_NICKNAME(HttpStatus.BAD_REQUEST, "PROFILE40002", "닉네임이 일치하지 않습니다."),;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandService.java
+++ b/src/main/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandService.java
@@ -1,13 +1,16 @@
 package naughty.tuzamate.domain.profile.service.command;
 
 import lombok.RequiredArgsConstructor;
+import naughty.tuzamate.domain.profile.dto.request.DeleteUserRequestDto;
 import naughty.tuzamate.domain.profile.dto.response.ProfileResponseDTO;
+import naughty.tuzamate.domain.profile.error.ProfileErrorCode;
 import naughty.tuzamate.domain.profile.repository.ProfileRepository;
 import naughty.tuzamate.domain.user.dto.UserInitProfileRequestDTO;
 import naughty.tuzamate.domain.user.entity.User;
 import naughty.tuzamate.domain.user.error.UserErrorCode;
 import naughty.tuzamate.domain.user.error.exception.UserCustomException;
 import naughty.tuzamate.domain.user.repository.UserRepository;
+import naughty.tuzamate.global.error.exception.CustomException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,5 +36,15 @@ public class ProfileCommandService {
         userRepository.save(user);
 
         return ProfileResponseDTO.profileInitResponse.of(user);
+    }
+
+    public void deleteProfile(User user, DeleteUserRequestDto dto) {
+
+        if (!user.getNickname().equals(dto.nickname())) {
+            throw new CustomException(ProfileErrorCode.MISMATCHED_NICKNAME);
+        }
+
+        user.withdraw();
+        userRepository.save(user);
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/user/entity/User.java
+++ b/src/main/java/naughty/tuzamate/domain/user/entity/User.java
@@ -72,6 +72,8 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private int tokenVersion = 0;
 
+    private boolean isDeleted; // 회원 탈퇴 여부
+
     public void increaseTokenVersion() {
         this.tokenVersion++;
     }
@@ -86,5 +88,11 @@ public class User extends BaseTimeEntity {
 
     public void updateFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
+    }
+
+    public void withdraw() {
+        this.isDeleted = true;
+        this.nickname = null;
+        this.email = "deleted_" + this.id + "@tuzamate"; // 이메일을 변경하여 탈퇴 회원임을 표시
     }
 }

--- a/src/main/java/naughty/tuzamate/domain/user/entity/User.java
+++ b/src/main/java/naughty/tuzamate/domain/user/entity/User.java
@@ -72,6 +72,7 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private int tokenVersion = 0;
 
+    @Column(nullable = false)
     private boolean isDeleted; // 회원 탈퇴 여부
 
     public void increaseTokenVersion() {

--- a/src/test/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandServiceTest.java
+++ b/src/test/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandServiceTest.java
@@ -1,5 +1,6 @@
 package naughty.tuzamate.domain.profile.service.command;
 
+import naughty.tuzamate.domain.profile.dto.request.DeleteUserRequestDto;
 import naughty.tuzamate.domain.profile.dto.response.ProfileResponseDTO;
 import naughty.tuzamate.domain.user.dto.UserInitProfileRequestDTO;
 import naughty.tuzamate.domain.user.entity.User;
@@ -40,5 +41,25 @@ class ProfileCommandServiceTest {
         // then
         Assertions.assertThat(response.nickname()).isEqualTo(user.getNickname());
         Assertions.assertThat(user.getExperience()).isEqualTo(user.getExperience());
+    }
+
+    @Test
+    void deleteProfile() {
+
+        // given
+        User user = User.builder().id(1L).nickname("nickname1").email("email1").build();
+        DeleteUserRequestDto dto = new DeleteUserRequestDto("nickname1");
+
+        String prevEmail = user.getEmail();
+
+        // when
+        profileCommandService.deleteProfile(user, dto);
+
+        // then
+        Assertions.assertThat(user.getNickname()).isNull();
+        Assertions.assertThat(user.isDeleted()).isTrue();
+        Assertions.assertThat(userRepository.existsByNickname(dto.nickname())).isFalse();
+        Assertions.assertThat(user.getEmail()).isNotEqualTo(prevEmail);
+
     }
 }

--- a/src/test/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandServiceTest.java
+++ b/src/test/java/naughty/tuzamate/domain/profile/service/command/ProfileCommandServiceTest.java
@@ -5,6 +5,7 @@ import naughty.tuzamate.domain.profile.dto.response.ProfileResponseDTO;
 import naughty.tuzamate.domain.user.dto.UserInitProfileRequestDTO;
 import naughty.tuzamate.domain.user.entity.User;
 import naughty.tuzamate.domain.user.repository.UserRepository;
+import naughty.tuzamate.global.error.exception.CustomException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,6 +61,18 @@ class ProfileCommandServiceTest {
         Assertions.assertThat(user.isDeleted()).isTrue();
         Assertions.assertThat(userRepository.existsByNickname(dto.nickname())).isFalse();
         Assertions.assertThat(user.getEmail()).isNotEqualTo(prevEmail);
+
+    }
+
+    @Test
+    void deleteProfileWhenNicknameMismatch() {
+
+        // given
+        User user = User.builder().id(1L).nickname("nickname1").email("email1").build();
+        DeleteUserRequestDto dto = new DeleteUserRequestDto("nickname2");
+
+        // then
+        assertThrows(CustomException.class, () -> profileCommandService.deleteProfile(user, dto));
 
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #76 

## 📌 개요
- soft delete 형태의 탈퇴
- isDeleted 필드를 추가해 탈퇴 표시
- 탈퇴 계정과 별개로 새로운 계정 생성하도록 구성
- nickname을 null로 변경
- 기존 이메일을 임의의 이메일로 변경

## 🔁 변경 사항
user 엔티티의 필드 값에 isDeleted 추가

## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] PR에 적절한 라벨을 선택
- [x] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for users to delete their profile by confirming their nickname.
  * Users who delete their profile will have their account marked as deleted, with their nickname cleared and email anonymized.

* **Bug Fixes**
  * Added error handling for mismatched nicknames during profile deletion, providing a clear error message if the nickname does not match.

* **Tests**
  * Introduced tests to verify the profile deletion process and its effects on user data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->