### PR TITLE
[Refactor] 나스닥 주식 정보 저장 코드 수정

### DIFF
--- a/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
@@ -29,6 +29,7 @@ public class StockController {
     private final KrxInquireService krxInquireService;
     private final KrxFinancialService krxFinancialService;
     private final StockInfoService stockInfoService;
+    private final AsyncNasdaqStockFetcher asyncNasdaqStockFetcher;
 
     @PostMapping("/post-stock-codes")
     @Operation(summary = "주식 코드 저장", description = "코스피, 코스닥, 나스닥 주식 코드를 저장합니다.")
@@ -48,7 +49,11 @@ public class StockController {
             description = "나스닥 주식 한 개의 기본 정보를 가져옵니다. 주식 코드를 입력해야 합니다.")
     public NasdaqDto.NasdaqInfoDto getNasdaqStockInfo(@PathVariable("nasdaqStockCode") String nasdaqStockCode) {
 
-        return nasdaqService.getCurrentNasdaqInfo(nasdaqStockCode);
+        try {
+            return asyncNasdaqStockFetcher.getCurrentNasdaqInfo(nasdaqStockCode);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @PostMapping("/nasdaq/all")

--- a/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/controller/StockController.java
@@ -49,11 +49,7 @@ public class StockController {
             description = "나스닥 주식 한 개의 기본 정보를 가져옵니다. 주식 코드를 입력해야 합니다.")
     public NasdaqDto.NasdaqInfoDto getNasdaqStockInfo(@PathVariable("nasdaqStockCode") String nasdaqStockCode) {
 
-        try {
             return asyncNasdaqStockFetcher.getCurrentNasdaqInfo(nasdaqStockCode);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 
     @PostMapping("/nasdaq/all")

--- a/src/main/java/naughty/tuzamate/domain/stock/service/AsyncNasdaqStockFetcher.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/AsyncNasdaqStockFetcher.java
@@ -1,0 +1,146 @@
+package naughty.tuzamate.domain.stock.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.RateLimiter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import naughty.tuzamate.auth.hantu.service.HantuApiTokenService;
+import naughty.tuzamate.domain.stock.dto.StockInfoDto;
+import naughty.tuzamate.domain.stock.dto.nasdaq.NasdaqDto;
+import naughty.tuzamate.domain.stock.entity.NasdaqStockInfo;
+import naughty.tuzamate.domain.stock.strategy.FilterStrategy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AsyncNasdaqStockFetcher {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final HantuApiTokenService hantuApiTokenService;
+    private final StockInfoService stockInfoService;
+    private final FilterStrategy filterStrategy;
+
+    private final RateLimiter rateLimiter = RateLimiter.create(15.0, 1, TimeUnit.SECONDS);
+
+    @Value("${tuza.api.APP_KEY}")
+    private String appKey;
+
+    @Value("${tuza.api.APP_SECRET_KEY}")
+    private String appSecret;
+
+    @Async("taskExecutor")
+    public CompletableFuture<Optional<NasdaqStockInfo>> fetchStock(String stockCode) {
+
+        try {
+            rateLimiter.acquire(3);
+
+
+            // 한투 API 호출에 필요한 헤더 생성
+            HttpHeaders header = createHeaders();
+            String url = "https://openapi.koreainvestment.com:9443/uapi/overseas-price/v1/quotations/price-detail";
+            HttpEntity<?> httpEntity = new HttpEntity<>(header);
+
+            UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url)
+                    .queryParam("AUTH", "")
+                    .queryParam("EXCD", "NAS")
+                    .queryParam("SYMB", stockCode);
+
+            // 한투 API 호출
+            ResponseEntity<String> response = restTemplate.exchange(
+                    builder.toUriString(),
+                    HttpMethod.GET,
+                    httpEntity,
+                    String.class
+            );
+
+            // 응답 파싱
+            NasdaqDto.NasdaqInfoDto currentNasdaqInfo = parsingCurrentNasdaqInfo(response.getBody(), stockCode);
+
+            // 필터링 전략 적용
+            if (filterStrategy.shouldSkipNasdaq(currentNasdaqInfo)) {
+                log.info("PER or PBR or EPS is zero: {}", stockCode);
+                return CompletableFuture.completedFuture(Optional.empty());
+            }
+
+            // 추가 주식 정보 조회
+            StockInfoDto.InfoDto currentStockInfo = stockInfoService.getStockInfo(stockCode, "512");
+
+            NasdaqStockInfo entity = currentNasdaqInfo.toEntity(currentNasdaqInfo, currentStockInfo);
+
+            return CompletableFuture.completedFuture(Optional.of(entity));
+
+        } catch (Exception e) {
+            log.error("Nasdaq 정보 조회 중 오류 발생. StockCode: {}, Error: {}", stockCode, e.getMessage());
+            return CompletableFuture.completedFuture(Optional.empty()); // 오류 발생 시 빈 Optional 반환
+        }
+    }
+
+    private HttpHeaders createHeaders() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        String accessToken = hantuApiTokenService.getCurrentAccessToken();
+
+        httpHeaders.setBearerAuth(accessToken);
+        httpHeaders.set("appkey", appKey);
+        httpHeaders.set("appsecret", appSecret);
+        httpHeaders.set("tr_id", "HHDFS76200200");
+        httpHeaders.set("custtype", "P");
+
+        return httpHeaders;
+    }
+
+    private NasdaqDto.NasdaqInfoDto parsingCurrentNasdaqInfo(String response, String stockCode) throws Exception {
+
+        JsonNode rootNode = objectMapper.readTree(response);
+        JsonNode node = rootNode.path("output");
+
+        NasdaqDto.NasdaqInfoDto outputDto = new NasdaqDto.NasdaqInfoDto();
+        outputDto.setCode(stockCode);
+        outputDto.setPerx(node.path("perx").asText());
+        outputDto.setPbrx(node.path("pbrx").asText());
+        outputDto.setEpsx(node.path("epsx").asText());
+        outputDto.setE_icod(node.path("e_icod").asText());
+        outputDto.setLast(node.path("last").asText());
+
+        return outputDto;
+    }
+
+    // 현재 나스닥 주식 정보 조회 메소드
+    // 없어도 되지만 컨트롤러의 getNasdaqStockInfo 메소드의 나스닥 단일 코드로 조회하는 테스트 용 메소드이다.
+    public NasdaqDto.NasdaqInfoDto getCurrentNasdaqInfo(String stockCode) throws Exception {
+
+
+        HttpHeaders header = createHeaders();
+
+        String url = "https://openapi.koreainvestment.com:9443/uapi/overseas-price/v1/quotations/price-detail";
+
+        HttpEntity<?> httpEntity = new HttpEntity<>(header);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url)
+                .queryParam("AUTH", "")
+                .queryParam("EXCD", "NAS")
+                .queryParam("SYMB", stockCode);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                builder.toUriString(),
+                HttpMethod.GET,
+                httpEntity,
+                String.class
+        );
+
+        return parsingCurrentNasdaqInfo(response.getBody(), stockCode);
+
+    }
+}

--- a/src/main/java/naughty/tuzamate/domain/stock/service/AsyncNasdaqStockFetcher.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/AsyncNasdaqStockFetcher.java
@@ -47,7 +47,6 @@ public class AsyncNasdaqStockFetcher {
             rateLimiter.acquire(3);
 
 
-            // 한투 API 호출에 필요한 헤더 생성
             HttpHeaders header = createHeaders();
             String url = "https://openapi.koreainvestment.com:9443/uapi/overseas-price/v1/quotations/price-detail";
             HttpEntity<?> httpEntity = new HttpEntity<>(header);
@@ -57,7 +56,6 @@ public class AsyncNasdaqStockFetcher {
                     .queryParam("EXCD", "NAS")
                     .queryParam("SYMB", stockCode);
 
-            // 한투 API 호출
             ResponseEntity<String> response = restTemplate.exchange(
                     builder.toUriString(),
                     HttpMethod.GET,
@@ -65,16 +63,14 @@ public class AsyncNasdaqStockFetcher {
                     String.class
             );
 
-            // 응답 파싱
             NasdaqDto.NasdaqInfoDto currentNasdaqInfo = parsingCurrentNasdaqInfo(response.getBody(), stockCode);
 
-            // 필터링 전략 적용
+            // 한국 주식과 마찬가지로 필터링
             if (filterStrategy.shouldSkipNasdaq(currentNasdaqInfo)) {
                 log.info("PER or PBR or EPS is zero: {}", stockCode);
                 return CompletableFuture.completedFuture(Optional.empty());
             }
 
-            // 추가 주식 정보 조회
             StockInfoDto.InfoDto currentStockInfo = stockInfoService.getStockInfo(stockCode, "512");
 
             NasdaqStockInfo entity = currentNasdaqInfo.toEntity(currentNasdaqInfo, currentStockInfo);
@@ -101,25 +97,29 @@ public class AsyncNasdaqStockFetcher {
         return httpHeaders;
     }
 
-    private NasdaqDto.NasdaqInfoDto parsingCurrentNasdaqInfo(String response, String stockCode) throws Exception {
+    private NasdaqDto.NasdaqInfoDto parsingCurrentNasdaqInfo(String response, String stockCode)  {
 
-        JsonNode rootNode = objectMapper.readTree(response);
-        JsonNode node = rootNode.path("output");
+        try {
+            JsonNode rootNode = objectMapper.readTree(response);
+            JsonNode node = rootNode.path("output");
 
-        NasdaqDto.NasdaqInfoDto outputDto = new NasdaqDto.NasdaqInfoDto();
-        outputDto.setCode(stockCode);
-        outputDto.setPerx(node.path("perx").asText());
-        outputDto.setPbrx(node.path("pbrx").asText());
-        outputDto.setEpsx(node.path("epsx").asText());
-        outputDto.setE_icod(node.path("e_icod").asText());
-        outputDto.setLast(node.path("last").asText());
+            NasdaqDto.NasdaqInfoDto outputDto = new NasdaqDto.NasdaqInfoDto();
+            outputDto.setCode(stockCode);
+            outputDto.setPerx(node.path("perx").asText());
+            outputDto.setPbrx(node.path("pbrx").asText());
+            outputDto.setEpsx(node.path("epsx").asText());
+            outputDto.setE_icod(node.path("e_icod").asText());
+            outputDto.setLast(node.path("last").asText());
 
-        return outputDto;
+            return outputDto;
+        } catch (Exception e) {
+            throw new RuntimeException("Error parsing response: " + e.getMessage(), e);
+        }
     }
 
     // 현재 나스닥 주식 정보 조회 메소드
     // 없어도 되지만 컨트롤러의 getNasdaqStockInfo 메소드의 나스닥 단일 코드로 조회하는 테스트 용 메소드이다.
-    public NasdaqDto.NasdaqInfoDto getCurrentNasdaqInfo(String stockCode) throws Exception {
+    public NasdaqDto.NasdaqInfoDto getCurrentNasdaqInfo(String stockCode)  {
 
 
         HttpHeaders header = createHeaders();

--- a/src/main/java/naughty/tuzamate/domain/stock/service/NasdaqService.java
+++ b/src/main/java/naughty/tuzamate/domain/stock/service/NasdaqService.java
@@ -15,130 +15,60 @@ import naughty.tuzamate.domain.stock.strategy.FilterStrategy;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class NasdaqService {
 
-    private final RestTemplate restTemplate;
-    private final ObjectMapper objectMapper;
     private final NasdaqCodeRepository nasdaqCodeRepository;
     private final NasdaqStockInfoRepository nasdaqStockInfoRepository;
-    private final HantuApiTokenService hantuApiTokenService;
-    private final StockInfoService stockInfoService;
-    private final FilterStrategy filterStrategy;
+    private final AsyncNasdaqStockFetcher asyncNasdaqStockFetcher;
 
-    @Value("${tuza.api.APP_KEY}")
-    private String appKey;
-
-    @Value("${tuza.api.APP_SECRET_KEY}")
-    private String appSecret;
-
-    private String accessToken;
-
-    private HttpHeaders createHeaders() {
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
-        accessToken = hantuApiTokenService.getCurrentAccessToken();
-
-        httpHeaders.setBearerAuth(accessToken);
-        httpHeaders.set("appkey", appKey);
-        httpHeaders.set("appsecret", appSecret);
-        httpHeaders.set("tr_id", "HHDFS76200200");
-        httpHeaders.set("custtype", "P");
-
-        return httpHeaders;
-    }
-
-    private NasdaqDto.NasdaqInfoDto parsingCurrentNasdaqInfo(String response, String stockCode) {
-        NasdaqDto.NasdaqInfoDto data = new NasdaqDto.NasdaqInfoDto();
-
-        try {
-            JsonNode rootNode = objectMapper.readTree(response);
-            JsonNode node = rootNode.path("output");
-
-            if (node != null) {
-                NasdaqDto.NasdaqInfoDto outputDto = new NasdaqDto.NasdaqInfoDto();
-
-                outputDto.setCode(stockCode);
-                outputDto.setPerx(node.path("perx").asText());
-                outputDto.setPbrx(node.path("pbrx").asText());
-                outputDto.setEpsx(node.path("epsx").asText());
-                outputDto.setE_icod(node.path("e_icod").asText());
-                outputDto.setLast(node.path("last").asText());
-
-
-                data = outputDto;
-            }
-            return data;
-        } catch (Exception e) {
-            log.error("error is : {}", e.getMessage());
-            throw new RuntimeException();
-        }
-    }
-
-    public NasdaqDto.NasdaqInfoDto getCurrentNasdaqInfo(String stockCode) {
-
-
-        HttpHeaders header = createHeaders();
-
-        String url = "https://openapi.koreainvestment.com:9443/uapi/overseas-price/v1/quotations/price-detail";
-
-        HttpEntity<?> httpEntity = new HttpEntity<>(header);
-
-        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url)
-                .queryParam("AUTH", "")
-                .queryParam("EXCD", "NAS")
-                .queryParam("SYMB", stockCode);
-
-        ResponseEntity<String> response = restTemplate.exchange(
-                builder.toUriString(),
-                HttpMethod.GET,
-                httpEntity,
-                String.class
-        );
-
-        return parsingCurrentNasdaqInfo(response.getBody(), stockCode);
-
-    }
-
+    @Transactional
     public void saveNasdaqStocksInfo() {
-        List<NasdaqStockCode> stockCodeList = nasdaqCodeRepository.findAll();
+        log.info("미국 주식 정보 저장/업데이트 시작");
+        long start = System.currentTimeMillis();
 
+        // 기존 데이터 삭제
         nasdaqStockInfoRepository.deleteAllInBatch();
 
-        for (NasdaqStockCode stockCode : stockCodeList) {
-            try {
+        List<NasdaqStockCode> stockCodeList = nasdaqCodeRepository.findAll();
 
-                Thread.sleep(100);
+        // 비동기 API 호출
+        List<CompletableFuture<Optional<NasdaqStockInfo>>> completableFutures = stockCodeList.stream()
+                .map(stockCode -> asyncNasdaqStockFetcher.fetchStock(stockCode.getCode()))
+                .toList();
 
-                NasdaqDto.NasdaqInfoDto currentNasdaqInfo = getCurrentNasdaqInfo(stockCode.getCode());
-                StockInfoDto.InfoDto currentStockInfo = stockInfoService.getStockInfo(stockCode.getCode(), "512");
+        log.info("{}개의 나스닥 주식 정보 요청 시작", stockCodeList.size());
 
-                if (filterStrategy.shouldSkipNasdaq(currentNasdaqInfo)) {
-                    log.info("PER or PBR or EPS is zero: {}", stockCode.getCode());
-                    continue; // 필터 전략에 의해 스킵된 경우 다음 주식 코드로 넘어감
-                }
+        // 모든 CompletableFuture가 완료될 때까지 기다린다
+        CompletableFuture.allOf(completableFutures.toArray(new CompletableFuture[0])).join();
+        log.info("모든 나스닥 주식 정보 요청 완료");
 
-                NasdaqStockInfo entity = currentNasdaqInfo.toEntity(currentNasdaqInfo, currentStockInfo);
+        // 결과를 Optional<NasdaqStockInfo>로 변환하여 리스트로 수집한다
+        List<NasdaqStockInfo> stockInfoList = completableFutures.stream()
+                .map(CompletableFuture::join)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
 
-                nasdaqStockInfoRepository.save(entity);
-
-                log.info("Saved stocks is : {}", stockCode.getCode());
-
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt(); // 현재 스레드 인터럽트 상태 복구
-                log.info("Thread Interrupted : {}", e.getMessage());
-                break;
-            } catch (Exception e) {
-                log.info("Error stock code is {} : {} and pass!", stockCode.getCode(), e.getMessage());
-            }
-
+        // 데이터 DB에 일괄 저장
+        if (!stockInfoList.isEmpty()) {
+            log.info("{} 개의 나스닥 주식 정보를 DB에 저장 시작", stockInfoList.size());
+            nasdaqStockInfoRepository.saveAll(stockInfoList);
         }
+
+        long end = System.currentTimeMillis();
+        log.info("나스닥 주식 정보 저장/업데이트 완료, 소요 시간: {} ms", (end - start));
+
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #79 

## 📌 개요
- 비동기 작업 담당 생성(AsyncNasdaqStockFetcher)
- NasdaqService 기존 코드와 달리 비동기 작업 호출 후 DB 일괄 저장
- 스레드는 기존 코드 이용(한국 주식 저장 시 구성했던)

## 🔁 변경 사항
- 기존 KrxService 코드 일부를 AsyncNasdaqStockFetcher로 이동
- KrxService에는 db에 save 하는 코드만으로 변경

## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced asynchronous fetching of Nasdaq stock information, improving performance and responsiveness.
  * Added filtering to skip stocks with zero PER, PBR, or EPS values.

* **Refactor**
  * Updated stock information saving to use batch operations and asynchronous processing.
  * Simplified and centralized error handling and removed manual API key and token management.
  * Streamlined code for improved concurrency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->