### PR TITLE
[Refactor] redis 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ repositories {
 }
 
 dependencies {
+
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -31,6 +33,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/naughty/tuzamate/auth/controller/AuthController.java
+++ b/src/main/java/naughty/tuzamate/auth/controller/AuthController.java
@@ -58,6 +58,6 @@ public class AuthController {
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-        return CustomResponse.onSuccess(AuthSuccessCode.ACCESS_TOKEN_REISSUE_SUCCESS_CODE);
+        return CustomResponse.onSuccess(AuthSuccessCode.ACCESS_TOKEN_REISSUE_SUCCESS_CODE, tokenDto);
     }
 }

--- a/src/main/java/naughty/tuzamate/auth/jwt/JwtProvider.java
+++ b/src/main/java/naughty/tuzamate/auth/jwt/JwtProvider.java
@@ -1,6 +1,7 @@
 package naughty.tuzamate.auth.jwt;
 
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +27,8 @@ public class JwtProvider {
 
     // @Value: yml에서 해당 값을 가져오기 (아래의 YML의 값을 가져올 수 있음)
     public JwtProvider(@Value("${JWT_SECRET}") String secret, @Value("${ACCESS_EXPIRATION}") long accessExpiration, @Value("${REFRESH_EXPIRATION}") long refreshExpiration) {
-        this.secret = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8)); // 가져온 문자열로 SecretKey 생성
+
+        this.secret = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
         this.accessExpiration = accessExpiration;
         this.refreshExpiration = refreshExpiration;
     }
@@ -73,9 +75,9 @@ public class JwtProvider {
     public Jws<Claims> getClaims(String token) {
         try {
             return Jwts.parser() // parsing 하기 위해 builder를 가져옴
-                    .setSigningKey(secret) // sign key 설정
+                    .verifyWith(secret) // sign key 설정
                     .build()
-                    .parseClaimsJws(token); // claim 가져오기
+                    .parseSignedClaims(token); // claim 가져오기
         } catch (Exception e) { // parsing하는 과정에서 sign key가 틀리는 등의 이유로 일어나는 Exception
             throw new AuthException(JwtErrorCode.TOKEN_INVALID);
         }

--- a/src/main/java/naughty/tuzamate/auth/service/AuthService.java
+++ b/src/main/java/naughty/tuzamate/auth/service/AuthService.java
@@ -11,8 +11,13 @@ import naughty.tuzamate.domain.user.error.UserErrorCode;
 import naughty.tuzamate.domain.user.error.exception.UserCustomException;
 import naughty.tuzamate.domain.user.repository.UserRepository;
 import naughty.tuzamate.global.error.exception.CustomException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +27,7 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
+    private final StringRedisTemplate redisTemplate;
 
     /**
      * user의 tokenVersion을 1 증가시킨다. -> 기존 토큰을 무효화 시킨다
@@ -56,19 +62,22 @@ public class AuthService {
             throw new CustomException(UserErrorCode.LOGGED_OUT_USER); // 의도적으로 토큰을 더 이상 신뢰하지 않는지 확인
         }
 
-        RefreshToken storedToken = refreshTokenRepository.findById(userId).orElseThrow(
-                () -> new CustomException(JwtErrorCode.TOKEN_INVALID));
+        String storedRefreshToken = redisTemplate.opsForValue().get("refreshToken:" + userId);
 
-        // 기존 리플레쉬 토큰을 재사용하지 못하도록 한다. (if문의 다음 코드를 사용하지 못하게)
-        if (!storedToken.getToken().equals(token)) { // 폐기된 토큰을 재사용 -> 탈취된 것
-            refreshTokenRepository.deleteById(userId);
+
+        if (storedRefreshToken == null || !storedRefreshToken.equals(token)) {
             throw new CustomException(JwtErrorCode.TOKEN_INVALID); // 저장된 토큰과 일치하지 않으면 예외 발생
         }
 
         String newAccessToken = jwtProvider.createAccessToken(user);
         String newRefreshToken = jwtProvider.createRefreshToken(user);
 
-        storedToken.update(newRefreshToken);
+        redisTemplate.opsForValue().set(
+                "refreshToken:" + userId,
+                newRefreshToken,
+                jwtProvider.getRefreshExpiration(),
+                TimeUnit.MILLISECONDS
+        );
 
         return new TokenResponse.TokenDto(newAccessToken, newRefreshToken);
 

--- a/src/main/java/naughty/tuzamate/auth/service/RefreshTokenService.java
+++ b/src/main/java/naughty/tuzamate/auth/service/RefreshTokenService.java
@@ -1,38 +1,59 @@
 package naughty.tuzamate.auth.service;
 
+import io.netty.util.internal.StringUtil;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import naughty.tuzamate.auth.entity.RefreshToken;
 import naughty.tuzamate.auth.repository.RefreshTokenRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
+import javax.swing.text.html.Option;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
-@Transactional
+//@Transactional
 public class RefreshTokenService {
 
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+    private ValueOperations<String, String> valueOperations;
 
-    public void saveRefreshToken(Long userId, String token, LocalDateTime expire) {
-
-        deleteToken(userId);
-
-        RefreshToken refreshToken = new RefreshToken(token, userId, expire);
-        refreshTokenRepository.save(refreshToken);
+    @PostConstruct
+    private void init() {
+        valueOperations = redisTemplate.opsForValue();
     }
 
-    public boolean validateToken(String token) {
+    public void saveRefreshToken(Long userId, String token, LocalDateTime expire) {
+        String key = "refreshToken:" + userId;
+        Duration ttl = Duration.between(LocalDateTime.now(), expire);
+        valueOperations.set(key, token, ttl);
+    }
+
+    public Optional<String> getRefreshToken(Long userId) {
+        String key = "refreshToken:" + userId;
+        String token = valueOperations.get(key);
+
+        return StringUtils.hasText(token) ? Optional.of(token) : Optional.empty();
+
+    }
+
+    public void deleteRefreshToken(Long userId) {
+        String key = "refreshToken:" + userId;
+        redisTemplate.delete(key);
+    }
+
+   /* public boolean validateToken(String token) {
 
         Optional<RefreshToken> refreshToken = refreshTokenRepository.findByToken(token);
         return refreshToken.isPresent() && refreshToken.get().getExpireDate().isAfter(LocalDateTime.now());
-    }
-
-    public void deleteToken(Long userId) {
-        refreshTokenRepository.deleteByUserId(userId);
-    }
+    }*/
 }

--- a/src/main/java/naughty/tuzamate/global/config/RedisConfig.java
+++ b/src/main/java/naughty/tuzamate/global/config/RedisConfig.java
@@ -1,0 +1,48 @@
+package naughty.tuzamate.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+
+        // redis 연결
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        // key, value 직렬화 설정
+        StringRedisSerializer serializer = new StringRedisSerializer();
+        redisTemplate.setKeySerializer(serializer);
+        redisTemplate.setValueSerializer(serializer);
+
+        // hash key, hash value 직렬화 설정
+        redisTemplate.setHashKeySerializer(serializer);
+        redisTemplate.setHashValueSerializer(serializer);
+
+        return redisTemplate;
+
+    }
+
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🏷️ 관련 이슈
Close #

## 📌 개요
- 레디스 적용
- 리플레시 토큰 작업 내용 변경
- redis 적용으로 인한 jwtProvider 내용 일부 변경

## 🔁 변경 사항
- 사용자의 리플레시 토큰을 기존 DB 저장에서 redis 적용으로 변경
## 📸 스크린샷

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하는지 확인
- [ ] PR에 적절한 라벨을 선택
- [ ] 관련 테스트 코드 작성
- [ ] 문서(README, Swagger 등) 업데이트

## 💡 추가 사항 (리뷰어가 참고해야 할 것)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Token refresh API now returns the new access and refresh tokens in the response body.
  - Enhanced JSON handling for Java 8 date/time types in API responses.

- Refactor
  - Modernized token processing for improved reliability.

- Chores
  - Introduced Redis-backed storage for refresh tokens to improve scalability and stability.
  - Added dependencies to support Redis and Java 8 date/time serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->